### PR TITLE
Include required hash functions.

### DIFF
--- a/library.json
+++ b/library.json
@@ -33,6 +33,9 @@
         ],
         "srcFilter": [
             "-<*>",
+            "+<crypto_generichash/blake2b>",
+            "+<crypto_stream/salsa20>",
+            "+<crypto_pwhash/argon2>",
             "+<crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c>",
             "+<crypto_core/ed25519/core_ed25519.c>",
             "+<crypto_core/ed25519/core_ristretto255.c>",


### PR DESCRIPTION
When building on a pio native platform, the link fails with undefined symbols. This PR adds the necessary source files to make this work.

Curiously, building on other platforms (e.g. ESP32) succeeds, evidently because on that platform the `srcFilter` in library.json is ignored and *all* source files are included in the build. 