### PR TITLE
Fix ChaCha20-Poly1305 AEAD source path

### DIFF
--- a/library.json
+++ b/library.json
@@ -36,7 +36,7 @@
             "+<crypto_stream/salsa20>",
             "+<crypto_core/salsa>",
             "+<randombytes>",
-            "+<crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c>",
+            "+<crypto_aead/chacha20poly1305/aead_chacha20poly1305.c>",
             "+<crypto_hash/crypto_hash.c>",
             "+<crypto_hash/sha256/cp/hash_sha256_cp.c>",
             "+<crypto_hash/sha256/hash_sha256.c>",


### PR DESCRIPTION
When trying to use the ChaCha20-Poly1305 AEAD functions (e.g., crypto_aead_chacha20poly1305_decrypt) in my ESPHome program, I ran into a linker error:

```
Successfully created ESP32 image.
Linking .pioenvs/doorbird-chime/firmware.elf
/data/cache/platformio/packages/toolchain-xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: .pioenvs/doorbird-chime/src/main.cpp.o:(.literal._ZNSt17_Function_handlerIFvSt6vectorIhSaIhEEEZ5setupvEUlS2_E_E9_M_invokeERKSt9_Any_dataOS2_+0x1c): undefined reference to `crypto_aead_chacha20poly1305_decrypt'
/data/cache/platformio/packages/toolchain-xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: .pioenvs/doorbird-chime/src/main.cpp.o: in function `_ZNSt17_Function_handlerIFvSt6vectorIhSaIhEEEZ5setupvEUlS2_E_E9_M_invokeERKSt9_Any_dataOS2_':
/config/esphome/doorbird-chime.yaml:124:(.text._ZNSt17_Function_handlerIFvSt6vectorIhSaIhEEEZ5setupvEUlS2_E_E9_M_invokeERKSt9_Any_dataOS2_+0xee): undefined reference to `crypto_aead_chacha20poly1305_decrypt'
collect2: error: ld returned 1 exit status
*** [.pioenvs/doorbird-chime/firmware.elf] Error 1
```

I discovered that `srcFilter` in library.json referenced a non-existent 'sodium/' subdirectory. I changed `crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c` to `crypto_aead/chacha20poly1305/aead_chacha20poly1305.c` and now it works fine.