### PR TITLE
Optimize poly1305 and chacha20 with aligned loads for Xtensa

### DIFF
--- a/patches/02-poly1305-aligned-loads.patch
+++ b/patches/02-poly1305-aligned-loads.patch
@@ -1,0 +1,145 @@
+diff --git a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna32.h b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna32.h
+index ed525008..be6b0218 100644
+--- a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna32.h
++++ b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna32.h
+@@ -1,6 +1,10 @@
+ /*
+    poly1305 implementation using 32 bit * 32 bit = 64 bit multiplication
+    and 64 bit addition
++
++   When the message pointer is 4-byte aligned, uses 4 aligned 32-bit loads
++   per block instead of 5 unaligned byte-at-a-time loads. This benefits
++   architectures (like Xtensa) where unaligned loads are expensive.
+ */
+ 
+ #if defined(_MSC_VER)
+@@ -12,6 +16,7 @@
+ #endif
+ 
+ #include "private/common.h"
++#include <stdint.h>
+ 
+ #define poly1305_block_size 16
+ 
+@@ -25,15 +30,56 @@ typedef struct poly1305_state_internal_t {
+     unsigned char      final;
+ } poly1305_state_internal_t;
+ 
++/* Load a 32-bit little-endian value from a pointer that is known to be
++   4-byte aligned. On little-endian targets this compiles to a single
++   aligned load instruction (e.g. l32i on Xtensa). */
++static inline __attribute__((always_inline)) uint32_t
++load32_le_aligned(const void *p) {
++#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
++    return *(const uint32_t *)p;
++#else
++    const uint8_t *b = (const uint8_t *)p;
++    return ((uint32_t)b[0])
++         | ((uint32_t)b[1] << 8)
++         | ((uint32_t)b[2] << 16)
++         | ((uint32_t)b[3] << 24);
++#endif
++}
++
+ static void
+ poly1305_init(poly1305_state_internal_t *st, const unsigned char key[32])
+ {
+     /* r &= 0xffffffc0ffffffc0ffffffc0fffffff - wiped after finalization */
+-    st->r[0] = (LOAD32_LE(&key[0])) & 0x3ffffff;
+-    st->r[1] = (LOAD32_LE(&key[3]) >> 2) & 0x3ffff03;
+-    st->r[2] = (LOAD32_LE(&key[6]) >> 4) & 0x3ffc0ff;
+-    st->r[3] = (LOAD32_LE(&key[9]) >> 6) & 0x3f03fff;
+-    st->r[4] = (LOAD32_LE(&key[12]) >> 8) & 0x00fffff;
++    if (((uintptr_t) key & 3) == 0) {
++        uint32_t k0 = load32_le_aligned(&key[0]);
++        uint32_t k1 = load32_le_aligned(&key[4]);
++        uint32_t k2 = load32_le_aligned(&key[8]);
++        uint32_t k3 = load32_le_aligned(&key[12]);
++
++        st->r[0] = k0 & 0x3ffffff;
++        st->r[1] = ((k0 >> 26) | (k1 << 6)) & 0x3ffff03;
++        st->r[2] = ((k1 >> 20) | (k2 << 12)) & 0x3ffc0ff;
++        st->r[3] = ((k2 >> 14) | (k3 << 18)) & 0x3f03fff;
++        st->r[4] = (k3 >> 8) & 0x00fffff;
++
++        /* save pad for later */
++        st->pad[0] = load32_le_aligned(&key[16]);
++        st->pad[1] = load32_le_aligned(&key[20]);
++        st->pad[2] = load32_le_aligned(&key[24]);
++        st->pad[3] = load32_le_aligned(&key[28]);
++    } else {
++        st->r[0] = (LOAD32_LE(&key[0])) & 0x3ffffff;
++        st->r[1] = (LOAD32_LE(&key[3]) >> 2) & 0x3ffff03;
++        st->r[2] = (LOAD32_LE(&key[6]) >> 4) & 0x3ffc0ff;
++        st->r[3] = (LOAD32_LE(&key[9]) >> 6) & 0x3f03fff;
++        st->r[4] = (LOAD32_LE(&key[12]) >> 8) & 0x00fffff;
++
++        /* save pad for later */
++        st->pad[0] = LOAD32_LE(&key[16]);
++        st->pad[1] = LOAD32_LE(&key[20]);
++        st->pad[2] = LOAD32_LE(&key[24]);
++        st->pad[3] = LOAD32_LE(&key[28]);
++    }
+ 
+     /* h = 0 */
+     st->h[0] = 0;
+@@ -42,12 +88,6 @@ poly1305_init(poly1305_state_internal_t *st, const unsigned char key[32])
+     st->h[3] = 0;
+     st->h[4] = 0;
+ 
+-    /* save pad for later */
+-    st->pad[0] = LOAD32_LE(&key[16]);
+-    st->pad[1] = LOAD32_LE(&key[20]);
+-    st->pad[2] = LOAD32_LE(&key[24]);
+-    st->pad[3] = LOAD32_LE(&key[28]);
+-
+     st->leftover = 0;
+     st->final    = 0;
+ }
+@@ -57,6 +97,7 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m,
+                 unsigned long long bytes)
+ {
+     const unsigned long hibit = (st->final) ? 0UL : (1UL << 24); /* 1 << 128 */
++    const int           aligned = (((uintptr_t) m & 3) == 0);
+     unsigned long       r0, r1, r2, r3, r4;
+     unsigned long       s1, s2, s3, s4;
+     unsigned long       h0, h1, h2, h3, h4;
+@@ -81,12 +122,32 @@ poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m,
+     h4 = st->h[4];
+ 
+     while (bytes >= poly1305_block_size) {
+-        /* h += m[i] */
+-        h0 += (LOAD32_LE(m + 0)) & 0x3ffffff;
+-        h1 += (LOAD32_LE(m + 3) >> 2) & 0x3ffffff;
+-        h2 += (LOAD32_LE(m + 6) >> 4) & 0x3ffffff;
+-        h3 += (LOAD32_LE(m + 9) >> 6) & 0x3ffffff;
+-        h4 += (LOAD32_LE(m + 12) >> 8) | hibit;
++        /*
++         * h += m[i]
++         *
++         * If m is 4-byte aligned, use 4 aligned 32-bit loads and
++         * reconstruct the 26-bit limbs with shifts. Otherwise fall
++         * back to the original 5 unaligned byte-at-a-time loads.
++         * Alignment is constant for all iterations (m advances by 16).
++         */
++        if (aligned) {
++            uint32_t w0 = load32_le_aligned(m + 0);
++            uint32_t w1 = load32_le_aligned(m + 4);
++            uint32_t w2 = load32_le_aligned(m + 8);
++            uint32_t w3 = load32_le_aligned(m + 12);
++
++            h0 += w0 & 0x3ffffff;
++            h1 += ((w0 >> 26) | (w1 << 6)) & 0x3ffffff;
++            h2 += ((w1 >> 20) | (w2 << 12)) & 0x3ffffff;
++            h3 += ((w2 >> 14) | (w3 << 18)) & 0x3ffffff;
++            h4 += (w3 >> 8) | hibit;
++        } else {
++            h0 += (LOAD32_LE(m + 0)) & 0x3ffffff;
++            h1 += (LOAD32_LE(m + 3) >> 2) & 0x3ffffff;
++            h2 += (LOAD32_LE(m + 6) >> 4) & 0x3ffffff;
++            h3 += (LOAD32_LE(m + 9) >> 6) & 0x3ffffff;
++            h4 += (LOAD32_LE(m + 12) >> 8) | hibit;
++        }
+ 
+         /* h *= r */
+         d0 = ((unsigned long long) h0 * r0) + ((unsigned long long) h1 * s4) +

--- a/patches/03-chacha20-aligned-loads.patch
+++ b/patches/03-chacha20-aligned-loads.patch
@@ -1,0 +1,175 @@
+diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+index 40cccbf8..e909780d 100644
+--- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
++++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+@@ -13,6 +13,35 @@
+ #include "crypto_stream_chacha20.h"
+ #include "private/common.h"
+ #include "utils.h"
++#include <stdint.h>
++
++/* Load/store 32-bit LE from a 4-byte aligned pointer.
++   On little-endian targets, compiles to a single aligned load/store. */
++static inline __attribute__((always_inline)) uint32_t
++chacha_load32_le_aligned(const void *p) {
++#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
++    return *(const uint32_t *)p;
++#else
++    const uint8_t *b = (const uint8_t *)p;
++    return ((uint32_t)b[0])
++         | ((uint32_t)b[1] << 8)
++         | ((uint32_t)b[2] << 16)
++         | ((uint32_t)b[3] << 24);
++#endif
++}
++
++static inline __attribute__((always_inline)) void
++chacha_store32_le_aligned(void *p, uint32_t v) {
++#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
++    *(uint32_t *)p = v;
++#else
++    uint8_t *b = (uint8_t *)p;
++    b[0] = (uint8_t)(v);
++    b[1] = (uint8_t)(v >> 8);
++    b[2] = (uint8_t)(v >> 16);
++    b[3] = (uint8_t)(v >> 24);
++#endif
++}
+ 
+ #include "../stream_chacha20.h"
+ #include "chacha20_ref.h"
+@@ -85,13 +114,15 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+         x15;
+     uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14,
+         j15;
+-    uint8_t     *ctarget = NULL;
+-    uint8_t      tmp[64];
+-    unsigned int i;
++    uint8_t                     *ctarget = NULL;
++    CRYPTO_ALIGN(4) uint8_t      tmp[64];
++    unsigned int                 i;
++    int                          aligned;
+ 
+     if (!bytes) {
+         return; /* LCOV_EXCL_LINE */
+     }
++    aligned = (((uintptr_t) m & 3) == 0) && (((uintptr_t) c & 3) == 0);
+     j0  = ctx->input[0];
+     j1  = ctx->input[1];
+     j2  = ctx->input[2];
+@@ -162,22 +193,41 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+         x14 = PLUS(x14, j14);
+         x15 = PLUS(x15, j15);
+ 
+-        x0  = XOR(x0, LOAD32_LE(m + 0));
+-        x1  = XOR(x1, LOAD32_LE(m + 4));
+-        x2  = XOR(x2, LOAD32_LE(m + 8));
+-        x3  = XOR(x3, LOAD32_LE(m + 12));
+-        x4  = XOR(x4, LOAD32_LE(m + 16));
+-        x5  = XOR(x5, LOAD32_LE(m + 20));
+-        x6  = XOR(x6, LOAD32_LE(m + 24));
+-        x7  = XOR(x7, LOAD32_LE(m + 28));
+-        x8  = XOR(x8, LOAD32_LE(m + 32));
+-        x9  = XOR(x9, LOAD32_LE(m + 36));
+-        x10 = XOR(x10, LOAD32_LE(m + 40));
+-        x11 = XOR(x11, LOAD32_LE(m + 44));
+-        x12 = XOR(x12, LOAD32_LE(m + 48));
+-        x13 = XOR(x13, LOAD32_LE(m + 52));
+-        x14 = XOR(x14, LOAD32_LE(m + 56));
+-        x15 = XOR(x15, LOAD32_LE(m + 60));
++        if (aligned) {
++            x0  = XOR(x0, chacha_load32_le_aligned(m + 0));
++            x1  = XOR(x1, chacha_load32_le_aligned(m + 4));
++            x2  = XOR(x2, chacha_load32_le_aligned(m + 8));
++            x3  = XOR(x3, chacha_load32_le_aligned(m + 12));
++            x4  = XOR(x4, chacha_load32_le_aligned(m + 16));
++            x5  = XOR(x5, chacha_load32_le_aligned(m + 20));
++            x6  = XOR(x6, chacha_load32_le_aligned(m + 24));
++            x7  = XOR(x7, chacha_load32_le_aligned(m + 28));
++            x8  = XOR(x8, chacha_load32_le_aligned(m + 32));
++            x9  = XOR(x9, chacha_load32_le_aligned(m + 36));
++            x10 = XOR(x10, chacha_load32_le_aligned(m + 40));
++            x11 = XOR(x11, chacha_load32_le_aligned(m + 44));
++            x12 = XOR(x12, chacha_load32_le_aligned(m + 48));
++            x13 = XOR(x13, chacha_load32_le_aligned(m + 52));
++            x14 = XOR(x14, chacha_load32_le_aligned(m + 56));
++            x15 = XOR(x15, chacha_load32_le_aligned(m + 60));
++        } else {
++            x0  = XOR(x0, LOAD32_LE(m + 0));
++            x1  = XOR(x1, LOAD32_LE(m + 4));
++            x2  = XOR(x2, LOAD32_LE(m + 8));
++            x3  = XOR(x3, LOAD32_LE(m + 12));
++            x4  = XOR(x4, LOAD32_LE(m + 16));
++            x5  = XOR(x5, LOAD32_LE(m + 20));
++            x6  = XOR(x6, LOAD32_LE(m + 24));
++            x7  = XOR(x7, LOAD32_LE(m + 28));
++            x8  = XOR(x8, LOAD32_LE(m + 32));
++            x9  = XOR(x9, LOAD32_LE(m + 36));
++            x10 = XOR(x10, LOAD32_LE(m + 40));
++            x11 = XOR(x11, LOAD32_LE(m + 44));
++            x12 = XOR(x12, LOAD32_LE(m + 48));
++            x13 = XOR(x13, LOAD32_LE(m + 52));
++            x14 = XOR(x14, LOAD32_LE(m + 56));
++            x15 = XOR(x15, LOAD32_LE(m + 60));
++        }
+ 
+         j12 = PLUSONE(j12);
+         /* LCOV_EXCL_START */
+@@ -186,22 +236,41 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+         }
+         /* LCOV_EXCL_STOP */
+ 
+-        STORE32_LE(c + 0, x0);
+-        STORE32_LE(c + 4, x1);
+-        STORE32_LE(c + 8, x2);
+-        STORE32_LE(c + 12, x3);
+-        STORE32_LE(c + 16, x4);
+-        STORE32_LE(c + 20, x5);
+-        STORE32_LE(c + 24, x6);
+-        STORE32_LE(c + 28, x7);
+-        STORE32_LE(c + 32, x8);
+-        STORE32_LE(c + 36, x9);
+-        STORE32_LE(c + 40, x10);
+-        STORE32_LE(c + 44, x11);
+-        STORE32_LE(c + 48, x12);
+-        STORE32_LE(c + 52, x13);
+-        STORE32_LE(c + 56, x14);
+-        STORE32_LE(c + 60, x15);
++        if (aligned) {
++            chacha_store32_le_aligned(c + 0, x0);
++            chacha_store32_le_aligned(c + 4, x1);
++            chacha_store32_le_aligned(c + 8, x2);
++            chacha_store32_le_aligned(c + 12, x3);
++            chacha_store32_le_aligned(c + 16, x4);
++            chacha_store32_le_aligned(c + 20, x5);
++            chacha_store32_le_aligned(c + 24, x6);
++            chacha_store32_le_aligned(c + 28, x7);
++            chacha_store32_le_aligned(c + 32, x8);
++            chacha_store32_le_aligned(c + 36, x9);
++            chacha_store32_le_aligned(c + 40, x10);
++            chacha_store32_le_aligned(c + 44, x11);
++            chacha_store32_le_aligned(c + 48, x12);
++            chacha_store32_le_aligned(c + 52, x13);
++            chacha_store32_le_aligned(c + 56, x14);
++            chacha_store32_le_aligned(c + 60, x15);
++        } else {
++            STORE32_LE(c + 0, x0);
++            STORE32_LE(c + 4, x1);
++            STORE32_LE(c + 8, x2);
++            STORE32_LE(c + 12, x3);
++            STORE32_LE(c + 16, x4);
++            STORE32_LE(c + 20, x5);
++            STORE32_LE(c + 24, x6);
++            STORE32_LE(c + 28, x7);
++            STORE32_LE(c + 32, x8);
++            STORE32_LE(c + 36, x9);
++            STORE32_LE(c + 40, x10);
++            STORE32_LE(c + 44, x11);
++            STORE32_LE(c + 48, x12);
++            STORE32_LE(c + 52, x13);
++            STORE32_LE(c + 56, x14);
++            STORE32_LE(c + 60, x15);
++        }
+ 
+         if (bytes <= 64) {
+             if (bytes < 64) {


### PR DESCRIPTION
## Summary

Optimize poly1305 and chacha20 with aligned 32-bit loads on little-endian embedded targets (Xtensa, RISC-V, ARM Cortex-M0+, BK72xx, RTL87xx).

### poly1305 (`02-poly1305-aligned-loads.patch`)

The poly1305 donna implementation uses 5 unaligned 32-bit loads at 3-byte strides per 16-byte block. On Xtensa, each `LOAD32_LE` from an unaligned address decomposes into 4 `l8ui` (byte load) instructions + shifts + ORs — 20 byte loads per block.

Optimization: Use 4 aligned loads at 4-byte strides and reconstruct the 26-bit limbs with shifts. Applied to both `poly1305_blocks` (hot loop) and `poly1305_init` (key loading). Runtime alignment check hoisted outside the loop — aligned path for bulk encrypt (heap buffers), unaligned fallback for handshake (stack buffers).

### chacha20 (`03-chacha20-aligned-loads.patch`)

The chacha20 encrypt loop does 16 `LOAD32_LE` + 16 `STORE32_LE` per 64-byte block. All accesses are at 4-byte multiples, so they can be directly replaced with aligned loads/stores when the buffer is aligned. Stack `tmp[64]` buffer aligned with `CRYPTO_ALIGN(4)`.

## Benchmark results

All platforms, poly1305 + chacha20 combined:

| Size | ESP32 (Xtensa LX6) | ESP32-S3 (Xtensa LX7) | ESP32-C3 (RISC-V) | BW15 (RTL87xx) | ESP8266 (Xtensa LX106) | RP2040 (Cortex-M0+) | CB3S (BK72xx) |
|------|-------------------|----------------------|-------------------|----------------|----------------------|--------------------|--------------| 
| 50B | 123.7→81.7 µs/op (-34.0%) | 83.2→71.7 µs/op (-13.8%) | 79.1→71.9 µs/op (-9.1%) | 76.6→73.2 µs/op (-4.4%) | 237.1→216.5 µs/op (-8.7%) | 174.0→159.2 µs/op (-8.5%) | 264.4→241.4 µs/op (-8.7%) |
| 100B | 149.4→98.7 µs/op (-33.9%) | 104.7→86.6 µs/op (-17.3%) | 100.9→87.2 µs/op (-13.6%) | 93.8→86.6 µs/op (-7.7%) | 324.7→293.8 µs/op (-9.5%) | 233.0→211.2 µs/op (-9.4%) | 347.3→318.2 µs/op (-8.4%) |
| 1000B | 557.5→382.1 µs/op (-31.5%) | 448.4→342.5 µs/op (-23.6%) | 465.0→368.0 µs/op (-20.9%) | 380.0→334.4 µs/op (-12.0%) | 1890.3→1699.2 µs/op (-10.1%) | 1209.9→1118.6 µs/op (-7.5%) | 1792.7→1615.6 µs/op (-9.9%) |

## How to reproduce benchmarks

<details>
<summary>noise_bench.h</summary>

```cpp
#pragma once
// Benchmark for noise-c ChaCha20-Poly1305 encrypt, matching the exact
// pattern used in APINoiseFrameHelper::write_protobuf_messages.

#include "noise/protocol.h"
#include "esphome/core/log.h"
#include "esphome/core/hal.h"
#include <cstring>

static const char *const BENCH_TAG = "noise_bench";

/// Run noise_cipherstate_encrypt on `msg_size` bytes, `iterations` times.
/// Uses the same cipher setup as the API noise frame helper:
///   NOISE_CIPHER_CHACHAPOLY with a 32-byte key.
static void noise_encrypt_benchmark(size_t msg_size, int iterations) {
  // Create a ChaChaPoly cipher state (same as handshake split produces)
  NoiseCipherState *cipher = nullptr;
  int err = noise_cipherstate_new_by_id(&cipher, NOISE_CIPHER_CHACHAPOLY);
  if (err != NOISE_ERROR_NONE || cipher == nullptr) {
    ESP_LOGE(BENCH_TAG, "Failed to create cipher state: %d", err);
    return;
  }

  // Init with a dummy 32-byte key
  uint8_t key[32];
  memset(key, 0xAB, sizeof(key));
  err = noise_cipherstate_init_key(cipher, key, sizeof(key));
  if (err != NOISE_ERROR_NONE) {
    ESP_LOGE(BENCH_TAG, "Failed to init key: %d", err);
    noise_cipherstate_free(cipher);
    return;
  }

  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
  // Allocate buffer: plaintext + room for MAC (same as frame helper)
  size_t buf_capacity = msg_size + mac_len;
  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);

  // Fill with dummy payload data
  memset(buffer.get(), 0x42, msg_size);

  ESP_LOGI(BENCH_TAG, "Benchmarking: %d x encrypt %zu bytes (+ %zu MAC)...",
           iterations, msg_size, mac_len);

  uint32_t start = micros();

  for (int i = 0; i < iterations; i++) {
    // Reset nonce each iteration to avoid nonce exhaustion
    // (real usage increments nonce per packet)
    noise_cipherstate_set_nonce(cipher, i);

    // Set up buffer exactly like write_protobuf_messages does:
    //   noise_buffer_set_inout(mbuf, data, data_len, capacity)
    NoiseBuffer mbuf;
    noise_buffer_set_inout(mbuf, buffer.get(), msg_size, buf_capacity);

    err = noise_cipherstate_encrypt(cipher, &mbuf);
    if (err != NOISE_ERROR_NONE) {
      ESP_LOGE(BENCH_TAG, "Encrypt failed at iteration %d: %d", i, err);
      break;
    }
  }

  uint32_t elapsed = micros() - start;

  float us_per_op = static_cast<float>(elapsed) / iterations;
  float mb_per_sec = (static_cast<float>(msg_size) * iterations) / elapsed;

  ESP_LOGI(BENCH_TAG, "Results: %u us total, %.1f us/op, %.2f MB/s",
           elapsed, us_per_op, mb_per_sec);
  ESP_LOGI(BENCH_TAG, "  msg_size=%zu, iterations=%d, mac_len=%zu",
           msg_size, iterations, mac_len);

  noise_cipherstate_free(cipher);
}
```

</details>

<details>
<summary>noise_bench_s3.yaml (ESP32-S3 example)</summary>

```yaml
esphome:
  name: noise-bench-s3
  friendly_name: Noise Benchmark S3
  includes:
    - noise_bench.h

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

logger:

api:
  encryption:
    key: "sIqZzuQU/xGLjGaRaA9DZaNtRzTAbgeNzsKMLKiqhSE="

ota:
  - platform: esphome

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

button:
  - platform: template
    name: "Benchmark Noise Encrypt 1000B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(1000, 1000);
  - platform: template
    name: "Benchmark Noise Encrypt 100B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(100, 5000);
  - platform: template
    name: "Benchmark Noise Encrypt 50B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(50, 10000);
```

</details>

Flash, connect via Home Assistant, and press the benchmark buttons. Results appear in the device logs.