### PR TITLE
Update libsodium submodule to 1.0.21

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "libsodium",
-    "version": "1.10020.7",
+    "version": "1.10021.0",
     "description": "ESPHome's libsodium port",
     "keywords": "libsodium",
     "repository": {


### PR DESCRIPTION
## Summary

- Update libsodium submodule from 1.0.20 to 1.0.21-RELEASE (176 commits)
- Bump library version from 1.10020.7 to 1.10021.0

## Changes in 1.0.21 affecting files we use

Only `crypto_core/ed25519/ref10/ed25519_ref10.c` was modified among the files included in our build. The poly1305 donna and chacha20 ref implementations are unchanged.

## Verification

- All 4 patches apply cleanly on 1.0.21:
  - `0003-add-stub-implementations.patch`
  - `01-esp8266-irom.patch`
  - `02-poly1305-aligned-loads.patch`
  - `03-chacha20-aligned-loads.patch`
- `pack.sh` runs successfully, produces `dist/libsodium-1.10021.0.tar.gz`
- Benchmarked on ESP32-S3 — performance matches 1.0.20 baseline (no regression):

| Size | 1.0.20 baseline | 1.0.21 baseline |
|------|-----------------|-----------------|
| 50B | 83.2 µs/op | 84.6 µs/op |
| 100B | 104.7 µs/op | 104.3 µs/op |
| 1000B | 448.4 µs/op | 450.4 µs/op |

## How to reproduce benchmarks

<details>
<summary>noise_bench.h</summary>

```cpp
#pragma once
// Benchmark for noise-c ChaCha20-Poly1305 encrypt, matching the exact
// pattern used in APINoiseFrameHelper::write_protobuf_messages.

#include "noise/protocol.h"
#include "esphome/core/log.h"
#include "esphome/core/hal.h"
#include <cstring>

static const char *const BENCH_TAG = "noise_bench";

/// Run noise_cipherstate_encrypt on `msg_size` bytes, `iterations` times.
/// Uses the same cipher setup as the API noise frame helper:
///   NOISE_CIPHER_CHACHAPOLY with a 32-byte key.
static void noise_encrypt_benchmark(size_t msg_size, int iterations) {
  // Create a ChaChaPoly cipher state (same as handshake split produces)
  NoiseCipherState *cipher = nullptr;
  int err = noise_cipherstate_new_by_id(&cipher, NOISE_CIPHER_CHACHAPOLY);
  if (err != NOISE_ERROR_NONE || cipher == nullptr) {
    ESP_LOGE(BENCH_TAG, "Failed to create cipher state: %d", err);
    return;
  }

  // Init with a dummy 32-byte key
  uint8_t key[32];
  memset(key, 0xAB, sizeof(key));
  err = noise_cipherstate_init_key(cipher, key, sizeof(key));
  if (err != NOISE_ERROR_NONE) {
    ESP_LOGE(BENCH_TAG, "Failed to init key: %d", err);
    noise_cipherstate_free(cipher);
    return;
  }

  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
  // Allocate buffer: plaintext + room for MAC (same as frame helper)
  size_t buf_capacity = msg_size + mac_len;
  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);

  // Fill with dummy payload data
  memset(buffer.get(), 0x42, msg_size);

  ESP_LOGI(BENCH_TAG, "Benchmarking: %d x encrypt %zu bytes (+ %zu MAC)...",
           iterations, msg_size, mac_len);

  uint32_t start = micros();

  for (int i = 0; i < iterations; i++) {
    // Reset nonce each iteration to avoid nonce exhaustion
    // (real usage increments nonce per packet)
    noise_cipherstate_set_nonce(cipher, i);

    // Set up buffer exactly like write_protobuf_messages does:
    //   noise_buffer_set_inout(mbuf, data, data_len, capacity)
    NoiseBuffer mbuf;
    noise_buffer_set_inout(mbuf, buffer.get(), msg_size, buf_capacity);

    err = noise_cipherstate_encrypt(cipher, &mbuf);
    if (err != NOISE_ERROR_NONE) {
      ESP_LOGE(BENCH_TAG, "Encrypt failed at iteration %d: %d", i, err);
      break;
    }
  }

  uint32_t elapsed = micros() - start;

  float us_per_op = static_cast<float>(elapsed) / iterations;
  float mb_per_sec = (static_cast<float>(msg_size) * iterations) / elapsed;

  ESP_LOGI(BENCH_TAG, "Results: %u us total, %.1f us/op, %.2f MB/s",
           elapsed, us_per_op, mb_per_sec);
  ESP_LOGI(BENCH_TAG, "  msg_size=%zu, iterations=%d, mac_len=%zu",
           msg_size, iterations, mac_len);

  noise_cipherstate_free(cipher);
}
```

</details>

<details>
<summary>noise_bench_s3.yaml (ESP32-S3 example)</summary>

```yaml
esphome:
  name: noise-bench-s3
  friendly_name: Noise Benchmark S3
  includes:
    - noise_bench.h

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

logger:

api:
  encryption:
    key: "sIqZzuQU/xGLjGaRaA9DZaNtRzTAbgeNzsKMLKiqhSE="

ota:
  - platform: esphome

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

button:
  - platform: template
    name: "Benchmark Noise Encrypt 1000B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(1000, 1000);
  - platform: template
    name: "Benchmark Noise Encrypt 100B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(100, 5000);
  - platform: template
    name: "Benchmark Noise Encrypt 50B"
    on_press:
      - lambda: |-
          noise_encrypt_benchmark(50, 10000);
```

</details>

Flash, connect via Home Assistant, and press the benchmark buttons. Results appear in the device logs.