### PR TITLE
Add permissions to upload release asset 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     name: Publish to PlatformIO
     runs-on: ubuntu-latest
     environment: platformio
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/esphome-libs/libsodium/security/code-scanning/2](https://github.com/esphome-libs/libsodium/security/code-scanning/2)

Add an explicit `permissions` block to the `publish-platformio` job in `.github/workflows/publish.yml`.

Best fix (minimal and behavior-preserving):
- In `jobs.publish-platformio`, add:
  - `contents: write` (required for uploading assets to a GitHub release via `softprops/action-gh-release`)
- Keep existing job logic unchanged.

Why this is best:
- It addresses the exact CodeQL finding.
- It uses least privilege for this job’s actual actions.
- It avoids broad workflow-wide permissions that could over-grant other jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
