### PR TITLE
Fix srcFilter path for port/version.c

### DIFF
--- a/library.json
+++ b/library.json
@@ -55,7 +55,7 @@
             "+<sodium/core.c>",
             "+<sodium/runtime.c>",
             "+<sodium/utils.c>",
-            "+<../../port/version.c>"
+            "+<../../../port/version.c>"
         ]
     }
 }


### PR DESCRIPTION
The last entry of `build.srcFilter` in `library.json` never matched any file, so `port/version.c` was silently excluded from every PlatformIO build.

PlatformIO resolves `srcFilter` patterns by joining them onto the *absolute* `srcDir` (see `match_src_files` in `platformio/fs.py`, and `PlatformIOLibBuilder.src_dir` in `piolib.py` which makes `srcDir` absolute against the library root). With `srcDir` set to `libsodium/src/libsodium`, two levels of `..` resolve to `libsodium/port/version.c`, which does not exist. The real file is at `port/version.c` in the repo root, which needs three.

The practical effect is that `sodium_version_string()`, `sodium_library_version_major()`, `sodium_library_version_minor()` and `sodium_library_minimal()` were declared in `sodium.h` but defined in no compiled translation unit, so any caller failed to link. Upstream's own `libsodium/src/libsodium/sodium/version.c` is deliberately excluded from the curated build and `port/version.c` exists to replace it, so this makes the declared API linkable rather than changing behaviour.

Verified against PlatformIO 6.1.19 with the submodule checked out and the repo's patches applied. Calling `match_src_files` directly with the repo's `srcDir` returns 29 sources and no `version.c` match before the change, and 30 sources including `../../../port/version.c` after. A throwaway `platform = native` project consuming the library via `symlink://` confirms the same end to end: `port/version.c` appears in the compiler invocations only after the fix, and a program calling all four symbols fails to link beforehand with four `undefined reference` errors and links and runs afterwards.

The ESP-IDF `CMakeLists.txt` also does not build `port/version.c`, but that is deliberately left alone here to avoid conflicting with separate in-flight work on that file.