### PR TITLE
Update repository URLs after repo transfer

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,3 @@
 description: ESPHome's libsodium port
 version: 1.10021.1
-repository: https://github.com/esphome/libsodium-esphome.git
+repository: https://github.com/esphome-libs/libsodium.git

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
     "keywords": "libsodium",
     "repository": {
         "type": "git",
-        "url": "https://github.com/esphome/libsodium-esphome.git"
+        "url": "https://github.com/esphome-libs/libsodium.git"
     },
     "export": {
         "include": [


### PR DESCRIPTION
This repo was transferred from `esphome/libsodium-esphome` to `esphome-libs/libsodium`. The old path still resolves through GitHub's redirect, which is why the stale URLs went unnoticed, but the ambiguity does confuse tooling: `gh pr create` failed outright against the old name with `No commits between esphome-libs:main and esphome:<branch> ... Head repository can't be blank`.

Both package manifests still recorded the pre-transfer URL. This points them at the canonical one:

- `library.json` `repository.url` (consumed by PlatformIO)
- `idf_component.yml` `repository` (consumed by the ESP Component Registry)

Deliberately left alone:

- The `--owner esphome` and `namespace: esphome` values in `.github/workflows/publish.yml`. Those are the PlatformIO and ESP Component Registry namespaces the packages are published under, not GitHub repo paths, and changing them would orphan the existing releases.
- The `# libsodium-esphome` heading in `README.md`. It is a title rather than a URL, and it still accurately describes the project.

Only the two `repository` URL fields changed; `name`, `version`, and `srcFilter` are untouched. Verified both manifests still parse (`jq` for `library.json`, `yaml.safe_load` for `idf_component.yml`).