### PR TITLE
Add generic CMake target for non-ESP-IDF consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-idf_component_register(
-  SRCS
+# Curated subset of libsodium sources built for ESPHome. Only the primitives
+# required by noise-c are compiled; the full tree is far too large for an MCU.
+set(LIBSODIUM_SRCS
   "libsodium/src/libsodium/crypto_aead/chacha20poly1305/aead_chacha20poly1305.c"
   "libsodium/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c"
   "libsodium/src/libsodium/crypto_core/salsa/ref/core_salsa_ref.c"
@@ -29,20 +30,57 @@ idf_component_register(
   "libsodium/src/libsodium/sodium/core.c"
   "libsodium/src/libsodium/sodium/runtime.c"
   "libsodium/src/libsodium/sodium/utils.c"
-  INCLUDE_DIRS
-  "libsodium/src/libsodium/include"
-  "libsodium/src/libsodium"
-  "libsodium/src/libsodium/include/sodium"
-  "port_include"
+  # Replaces upstream sodium/version.c, which cannot be used because including
+  # its version.h on ESP8266 picks up the ESP SDK's version.h instead.
+  "port/version.c"
 )
 
-target_compile_options(${COMPONENT_LIB} PUBLIC
-  "-D CONFIGURED=1"
-)
-
-target_compile_options(${COMPONENT_LIB} PRIVATE
+set(LIBSODIUM_COMPILE_OPTIONS
   "-Wno-unused-function"
   "-Wno-unknown-pragmas"
   "-Wno-unused-variable"
   "-Wno-type-limits"
 )
+
+if(ESP_PLATFORM)
+  # ESP-IDF component build.
+  idf_component_register(
+    SRCS ${LIBSODIUM_SRCS}
+    INCLUDE_DIRS
+    "libsodium/src/libsodium/include"
+    "libsodium/src/libsodium"
+    "libsodium/src/libsodium/include/sodium"
+    "port_include"
+  )
+
+  target_compile_options(${COMPONENT_LIB} PUBLIC
+    "-D CONFIGURED=1"
+  )
+
+  target_compile_options(${COMPONENT_LIB} PRIVATE ${LIBSODIUM_COMPILE_OPTIONS})
+else()
+  # Generic CMake build, for consumers that pull this repo in with
+  # add_subdirectory().
+  cmake_minimum_required(VERSION 3.13)
+
+  # crypto_stream/salsa20/xmm6/salsa20_xmm6-asm.S is compiled (it is empty
+  # unless HAVE_AMD64_ASM is defined, which this port never does), so the
+  # consuming project does not have to enable ASM itself.
+  enable_language(ASM)
+
+  add_library(sodium STATIC ${LIBSODIUM_SRCS})
+  add_library(esphome::sodium ALIAS sodium)
+
+  target_include_directories(sodium
+    PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium/include"
+    PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium/include/sodium"
+    "${CMAKE_CURRENT_SOURCE_DIR}/port_include"
+  )
+
+  target_compile_definitions(sodium PRIVATE CONFIGURED=1)
+
+  target_compile_options(sodium PRIVATE ${LIBSODIUM_COMPILE_OPTIONS})
+endif()

--- a/README.md
+++ b/README.md
@@ -6,4 +6,15 @@ We use libsodium 1.0.21 as the base (see libsodium submodule) with some simple p
 
 Only a subset of libsodium is compiled, namely the cryptographic primitives required for [noise-c](https://github.com/esphome/noise-c/).
 
+## Plain CMake
+
+Outside of ESP-IDF, `CMakeLists.txt` defines an ordinary static library target, so any CMake project can consume it directly:
+
+```cmake
+add_subdirectory(path/to/libsodium-esphome)
+target_link_libraries(my_target PRIVATE esphome::sodium)
+```
+
+The target is named `sodium`, with `esphome::sodium` as an alias. Include directories, `CONFIGURED=1` and the warning suppressions are all carried on the target.
+
 libsodium is licensed under the [ISC License](https://github.com/jedisct1/libsodium#license)


### PR DESCRIPTION
`CMakeLists.txt` was ESP-IDF-only, so plain CMake projects had no way to consume this library. It now splits on `ESP_PLATFORM`: the ESP-IDF path is unchanged, and a new generic path defines an ordinary static library target `sodium`, aliased as `esphome::sodium`, carrying its include directories, `CONFIGURED=1` and the warning suppressions on the target.

Both branches build from a single shared `LIBSODIUM_SRCS` list declared above the split, so the curated source set has exactly one definition and the two paths cannot drift. The warning flags are shared the same way. The generic branch also calls `enable_language(ASM)` so consumers do not have to enable ASM themselves for the one `.S` entry, which preprocesses to nothing unless `HAVE_AMD64_ASM` is defined.

Now that #24 corrected the `srcFilter` path, `port/version.c` is in the shared list too, so all three consumers build the same 30 files. This does mean the ESP-IDF component gains `sodium_version_string()` and friends, which it did not build before; that is additive and keeps ESP-IDF from being the odd one out.

Verified by diffing a real `pio run -v` compile set against `LIBSODIUM_SRCS` (30 vs 30, identical), building a scratch project that does `add_subdirectory()` and links `esphome::sodium` on both host and `arm-none-eabi` cortex-m0plus (clean, no warnings), and exercising the ESP-IDF branch with a stubbed `idf_component_register`.