### PR TITLE
Fix stale sodium version header

### DIFF
--- a/port_include/sodium/version.h
+++ b/port_include/sodium/version.h
@@ -7,10 +7,10 @@
 
 #include <sodium/export.h>
 
-#define SODIUM_VERSION_STRING "1.0.20"
+#define SODIUM_VERSION_STRING "1.0.21"
 
 #define SODIUM_LIBRARY_VERSION_MAJOR 26
-#define SODIUM_LIBRARY_VERSION_MINOR 2
+#define SODIUM_LIBRARY_VERSION_MINOR 3
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`port_include/sodium/version.h` is hand-maintained, because autoconf (which normally generates it) is not available under PlatformIO. That means it has to be updated by hand whenever the `libsodium` submodule moves, and the bump to 1.0.21 in #18 missed it: the header still declared `SODIUM_VERSION_STRING "1.0.20"` with library version 26.2, while the submodule has been pinned to `1.0.21-RELEASE` since then.

The practical effect is that `sodium_version_string()`, `sodium_library_version_major()` and `sodium_library_version_minor()` all report a version the port is not actually shipping.

The new values are copied verbatim from the submodule's own `builds/msvc/version.h` at `1.0.21-RELEASE`, which is the file this header's comment says it is derived from. Note that only the minor moved: upstream 1.0.21 really does keep `SODIUM_LIBRARY_VERSION_MAJOR` at 26 and bumps `SODIUM_LIBRARY_VERSION_MINOR` from 2 to 3.