### PR TITLE
Bump version to 1.10021.2

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,3 @@
 description: ESPHome's libsodium port
-version: 1.10021.1
+version: 1.10021.2
 repository: https://github.com/esphome-libs/libsodium.git

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "libsodium",
-    "version": "1.10021.1",
+    "version": "1.10021.2",
     "description": "ESPHome's libsodium port",
     "keywords": "libsodium",
     "repository": {


### PR DESCRIPTION
Releases the packaging and build fixes merged since 1.10021.1: #23, #24, #25 and #26.

Both manifests have to carry the same string, and it has to match the release tag exactly. `publish.yml` hardcodes `dist/libsodium-${{ github.event.release.tag_name }}.tar.gz` while `pio package pack` names that tarball from the `library.json` version, so any disagreement between the tag and these files fails the PlatformIO publish job.

Once this merges the release should be cut with the tag `1.10021.2`, with no `v` prefix, matching every existing tag in the repo.