### PR TITLE
Make port_include a PUBLIC include dir for the generic CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,13 @@ else()
   target_include_directories(sodium
     PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium/include"
+    # The public sodium.h includes "sodium/version.h", which this port ships
+    # pre-generated here instead of generating it from version.h.in, so
+    # port_include has to be on the consumer's include path too.
+    "${CMAKE_CURRENT_SOURCE_DIR}/port_include"
     PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium"
     "${CMAKE_CURRENT_SOURCE_DIR}/libsodium/src/libsodium/include/sodium"
-    "${CMAKE_CURRENT_SOURCE_DIR}/port_include"
   )
 
   target_compile_definitions(sodium PRIVATE CONFIGURED=1)


### PR DESCRIPTION
## Problem

The generic (non-ESP-IDF) target added in #26 marks `port_include` as a PRIVATE include directory. That directory holds the pre-generated `sodium/version.h` this port ships in place of upstream's autoconf-generated one, and the public `libsodium/src/libsodium/include/sodium.h` includes it on line 5.

So any consumer that does `target_link_libraries(mytarget sodium)` and then `#include <sodium.h>` fails to compile:

```
sodium.h:5:10: fatal error: sodium/version.h: No such file or directory
    5 | #include "sodium/version.h"
```

On a host that happens to have a system libsodium installed the failure is quieter but worse: the quoted include falls through to `/usr/include/sodium/version.h`, so the build silently compiles against a different libsodium's version macros.

## Fix

Move `port_include` from the PRIVATE to the PUBLIC section of `target_include_directories(sodium ...)`. It contains exactly one header, `sodium/version.h`, which is part of the public API surface, so there is nothing internal being leaked by publishing the directory.

The rest of the generic target was checked for the same class of problem and is fine as-is. The public headers reach each other through quoted relative includes that resolve next to the including file, so `libsodium/src/libsodium/include/sodium` can stay PRIVATE, and `CONFIGURED=1` is only tested by `include/sodium/private/common.h`, which is not reachable from the public `sodium.h`, so it can stay PRIVATE too.

The `if(ESP_PLATFORM)` branch is untouched and was never affected, since `idf_component_register` publishes all of its `INCLUDE_DIRS` to dependents.

## Context

The consumer is ESPHome's new bare pico-sdk framework for RP2040/RP2350, which builds libsodium and noise-c from source through plain CMake `add_subdirectory()` rather than via PlatformIO or ESP-IDF. noise-c's generic target does `if(TARGET sodium) target_link_libraries(noise_c PUBLIC sodium) endif()`, so it picks this library up automatically when both are added, which is the path that exposed the bug.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)