### PR TITLE
Automate version bumps with Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+# Tags are bare version strings with no "v" prefix (1.10021.2, 1.10021.1, ...).
+# publish.yml derives dist/libsodium-<tag>.tar.gz from the release tag, while
+# `pio package pack` names that tarball from the library.json version, so a
+# "v" prefix here would make the two disagree and break the publish job.
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+# This resolver is only a fallback. The version scheme here is
+# 1.<libsodium version as MAJOR*10000 + MINOR*100 + PATCH>.<port patch number>,
+# so libsodium 1.0.21 gives 1.10021.N. The minor field is not a semver minor:
+# it states which libsodium release the submodule is pinned to, so it cannot be
+# derived from PR labels at all. Release Drafter is therefore handed an explicit
+# `version:` computed in .github/workflows/release-drafter.yml, which reads the
+# libsodium version out of the submodule and overrides everything below.
+#
+# Labels only ever move the port patch number, hence patch-only here. Do not
+# restore the standard major/minor resolver: a "minor"/"new-feature" label
+# resolving 1.10021.2 -> 1.10022.0 would claim this port ships libsodium 1.0.22
+# when it does not.
+version-resolver:
+  patch:
+    labels:
+      - "bugfix"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/scripts/resolve_version.py
+++ b/.github/scripts/resolve_version.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Resolve the port version string for a release.
+
+The version scheme is NOT semver:
+
+    1.<libsodium version encoded as MAJOR*10000 + MINOR*100 + PATCH>.<port patch number>
+
+so libsodium 1.0.21 gives 1.10021.N. The minor field is therefore not a semver
+minor: it states which libsodium release the submodule is pinned to, and it is
+derived here from the submodule rather than hand-edited.
+
+The libsodium version comes from the release tag on the pinned commit, NOT
+from the submodule's configure.ac. Between releases upstream sets configure.ac
+to the next, unreleased version, so parsing it would claim we ship a libsodium
+that does not exist yet. Requiring a release tag means a pin to an untagged
+commit fails instead, which is correct: the version scheme has no way to
+express "somewhere between two libsodium releases".
+
+The patch counts port releases made against that libsodium version, so it
+continues from the newest published release sharing this minor and restarts
+at 0 whenever the submodule moves to a new libsodium release.
+
+This module is pure stdlib. The pure logic (tag parsing, version encoding,
+patch selection) lives in small functions that take plain data and have no
+network or subprocess dependency, so they are trivially unit testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+VersionTuple = tuple[int, int, int]
+
+DEFAULT_LIBSODIUM_REPO: str = "jedisct1/libsodium"
+DEFAULT_REPO: str = "esphome-libs/libsodium"
+GITHUB_API_ACCEPT: str = "application/vnd.github+json"
+PER_PAGE: int = 100
+
+# Upstream tags releases inconsistently: 1.0.21-RELEASE, 1.0.18-FINAL, and
+# 1.0.22 all name releases, and one commit can carry several.
+TAG_RE: re.Pattern[str] = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-RELEASE|-FINAL)?$")
+
+
+class VersionError(Exception):
+    """Raised when the version cannot be resolved."""
+
+
+# --------------------------------------------------------------------------
+# Pure logic - no network, no subprocess. Easy to unit test directly.
+# --------------------------------------------------------------------------
+
+
+def parse_tag(tag: str) -> VersionTuple | None:
+    """Parse a libsodium release tag into a (major, minor, patch) tuple.
+
+    Accepts "1.0.21-RELEASE", "1.0.18-FINAL", and bare "1.0.22" forms.
+    Returns None if the tag does not name a release.
+    """
+    match = TAG_RE.match(tag)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def tags_for_commit(tags: list[dict[str, Any]], sha: str) -> list[str]:
+    """Return the names of every tag whose commit sha equals sha.
+
+    The GitHub tags API's commit.sha is already peeled, which is why it is
+    used instead of the git refs API.
+    """
+    return [tag["name"] for tag in tags if tag.get("commit", {}).get("sha") == sha]
+
+
+def resolve_upstream_version(tag_names: list[str], pinned_sha: str) -> VersionTuple:
+    """Resolve the single libsodium version named by tag_names.
+
+    Raises VersionError if no tag names a release, or if more than one
+    distinct version is named (conflicting release tags on one commit).
+    """
+    versions: set[VersionTuple] = set()
+    for name in tag_names:
+        parsed = parse_tag(name)
+        if parsed is not None:
+            versions.add(parsed)
+
+    if not versions:
+        raise VersionError(
+            f"libsodium submodule is pinned to {pinned_sha}, which carries no "
+            "release tag. Pin it to a tagged libsodium release."
+        )
+
+    if len(versions) > 1:
+        formatted = " ".join(
+            f"{major}.{minor}.{patch}"
+            for major, minor, patch in sorted(versions)
+        )
+        raise VersionError(
+            f"libsodium commit {pinned_sha} carries conflicting release tags: "
+            f"{formatted}"
+        )
+
+    return next(iter(versions))
+
+
+def encode_minor(version: VersionTuple) -> int:
+    """Encode a (major, minor, patch) libsodium version into the minor field."""
+    major, minor, patch = version
+    return major * 10000 + minor * 100 + patch
+
+
+def non_draft_tag_names(releases: list[dict[str, Any]]) -> list[str]:
+    """Return the tag_name of every non-draft release. Prereleases are kept."""
+    return [
+        release["tag_name"] for release in releases if not release.get("draft", False)
+    ]
+
+
+def select_patch(tag_names: list[str], minor: int) -> int:
+    """Select the next port patch number for the given encoded minor.
+
+    Continues from the newest published release sharing this minor, or 0 if
+    none do.
+    """
+    pattern = re.compile(rf"^1\.{minor}\.(\d+)$")
+    numbers: list[int] = []
+    for name in tag_names:
+        match = pattern.match(name)
+        if match is not None:
+            numbers.append(int(match.group(1)))
+
+    if not numbers:
+        return 0
+    return max(numbers) + 1
+
+
+def format_version(version: VersionTuple) -> str:
+    major, minor, patch = version
+    return f"{major}.{minor}.{patch}"
+
+
+# --------------------------------------------------------------------------
+# I/O: subprocess and network.
+# --------------------------------------------------------------------------
+
+
+def get_pinned_sha() -> str:
+    """Return the commit sha the libsodium submodule gitlink is pinned to."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD:libsodium"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else str(error)
+        raise VersionError(f"Failed to resolve libsodium submodule pin: {stderr}") from error
+    return result.stdout.strip()
+
+
+def build_headers(token: str | None) -> dict[str, str]:
+    headers = {"Accept": GITHUB_API_ACCEPT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def http_get_json(url: str, token: str | None) -> Any:
+    request = urllib.request.Request(url, headers=build_headers(token))
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as error:
+        raise VersionError(f"Request to {url} failed: {error}") from error
+
+
+def paginate(base_url: str, token: str | None) -> list[dict[str, Any]]:
+    """Fetch every page of a GitHub list endpoint, per_page=100.
+
+    Follows pages until a short page (fewer than PER_PAGE items) is seen.
+    """
+    results: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in base_url else "?"
+        url = f"{base_url}{separator}per_page={PER_PAGE}&page={page}"
+        data = http_get_json(url, token)
+        results.extend(data)
+        if len(data) < PER_PAGE:
+            break
+        page += 1
+    return results
+
+
+def fetch_libsodium_tags(libsodium_repo: str, token: str | None) -> list[dict[str, Any]]:
+    try:
+        return paginate(f"https://api.github.com/repos/{libsodium_repo}/tags", token)
+    except VersionError as error:
+        raise VersionError(f"Failed to list {libsodium_repo} tags: {error}") from error
+
+
+def fetch_releases(repo: str, token: str | None) -> list[dict[str, Any]]:
+    try:
+        return paginate(f"https://api.github.com/repos/{repo}/releases", token)
+    except VersionError as error:
+        raise VersionError(f"Failed to list existing releases: {error}") from error
+
+
+# --------------------------------------------------------------------------
+# High level steps, shared between the two subcommands.
+# --------------------------------------------------------------------------
+
+
+def resolve_libsodium_version(libsodium_repo: str, token: str | None) -> tuple[VersionTuple, str]:
+    """Steps 1-3: resolve the libsodium release the submodule is pinned to.
+
+    Returns (version, pinned_sha).
+    """
+    pinned_sha = get_pinned_sha()
+    tags = fetch_libsodium_tags(libsodium_repo, token)
+    tag_names = tags_for_commit(tags, pinned_sha)
+    version = resolve_upstream_version(tag_names, pinned_sha)
+    return version, pinned_sha
+
+
+def resolve_port_version(libsodium_repo: str, repo: str, token: str | None) -> tuple[VersionTuple, str]:
+    """All steps: resolve the libsodium version and the full port version string.
+
+    Returns (libsodium_version, port_version_string).
+    """
+    version, _pinned_sha = resolve_libsodium_version(libsodium_repo, token)
+    minor = encode_minor(version)
+    releases = fetch_releases(repo, token)
+    release_tags = non_draft_tag_names(releases)
+    patch = select_patch(release_tags, minor)
+    return version, f"1.{minor}.{patch}"
+
+
+def write_github_output(version_string: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"version={version_string}\n")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def run_resolve(libsodium_repo: str, repo: str, token: str | None) -> None:
+    version, version_string = resolve_port_version(libsodium_repo, repo, token)
+    print(f"libsodium {format_version(version)} -> {version_string}")
+    write_github_output(version_string)
+
+
+def run_check(libsodium_repo: str, token: str | None) -> None:
+    version, _pinned_sha = resolve_libsodium_version(libsodium_repo, token)
+    print(format_version(version))
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Resolve the libsodium-esphome port version.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("resolve", help="Resolve the full port version and emit GITHUB_OUTPUT.")
+    subparsers.add_parser("check", help="Check that the submodule is pinned to a tagged libsodium release.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN")
+    libsodium_repo = DEFAULT_LIBSODIUM_REPO
+    repo = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO)
+
+    try:
+        if args.command == "check":
+            run_check(libsodium_repo, token)
+        else:
+            run_resolve(libsodium_repo, repo, token)
+    except VersionError as error:
+        print(f"::error::{error}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/.github/scripts/test_resolve_version.py
+++ b/.github/scripts/test_resolve_version.py
@@ -1,0 +1,573 @@
+"""Tests for resolve_version.py.
+
+Network is mocked at the urllib.request.urlopen layer; the git call is mocked
+via subprocess.run. No real network or subprocess call is made.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Iterator
+
+import pytest
+
+import resolve_version as rv
+
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, data: Any) -> None:
+        self._data = json.dumps(data).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def sequence_urlopen(responses: list[Any]) -> Callable[..., FakeResponse]:
+    """Build a fake urlopen returning one item from responses per call.
+
+    Each item is either JSON-serializable data, or an Exception instance to
+    raise instead.
+    """
+    it: Iterator[Any] = iter(responses)
+
+    def fake_urlopen(request: urllib.request.Request, *args: object, **kwargs: object) -> FakeResponse:
+        item = next(it)
+        if isinstance(item, Exception):
+            raise item
+        return FakeResponse(item)
+
+    return fake_urlopen
+
+
+def capturing_urlopen(
+    sink: list[urllib.request.Request], data: Any = None
+) -> Callable[..., FakeResponse]:
+    def fake_urlopen(request: urllib.request.Request, *args: object, **kwargs: object) -> FakeResponse:
+        sink.append(request)
+        return FakeResponse(data if data is not None else [])
+
+    return fake_urlopen
+
+
+def tag(name: str, sha: str) -> dict[str, Any]:
+    return {"name": name, "commit": {"sha": sha}}
+
+
+def release(tag_name: str, draft: bool = False) -> dict[str, Any]:
+    return {"tag_name": tag_name, "draft": draft}
+
+
+# --------------------------------------------------------------------------
+# Pure logic: parse_tag
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tag_name,expected",
+    [
+        ("1.0.21-RELEASE", (1, 0, 21)),
+        ("1.0.18-FINAL", (1, 0, 18)),
+        ("1.0.22", (1, 0, 22)),
+        ("v1.0.22", None),
+        ("not-a-version", None),
+        ("1.0.22-BETA", None),
+    ],
+)
+def test_parse_tag(tag_name: str, expected: tuple[int, int, int] | None) -> None:
+    assert rv.parse_tag(tag_name) == expected
+
+
+# --------------------------------------------------------------------------
+# Pure logic: encode_minor
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        # Every libsodium release so far has been 1.0.x, so these three are the
+        # cases with real historical evidence behind them.
+        ((1, 0, 18), 10018),
+        ((1, 0, 20), 10020),
+        ((1, 0, 21), 10021),
+        # No libsodium release has ever had a non-zero minor, so nothing above
+        # exercises the minor term at all. These pin down the encoding as a
+        # zero-padded concatenation of the three fields (1.1.0 -> 1|01|00), so
+        # a future libsodium 1.1.x cannot silently collide with a 1.0.x port
+        # version.
+        ((1, 1, 0), 10100),
+        ((1, 2, 3), 10203),
+        ((1, 10, 21), 11021),
+        ((2, 0, 0), 20000),
+    ],
+)
+def test_encode_minor(version: tuple[int, int, int], expected: int) -> None:
+    assert rv.encode_minor(version) == expected
+
+
+def test_format_version() -> None:
+    assert rv.format_version((1, 0, 21)) == "1.0.21"
+
+
+# --------------------------------------------------------------------------
+# Pure logic: tags_for_commit
+# --------------------------------------------------------------------------
+
+
+def test_tags_for_commit_matches_only_pinned_sha() -> None:
+    tags = [
+        tag("1.0.21-RELEASE", "abc123"),
+        tag("1.0.20-RELEASE", "def456"),
+        {"name": "no-commit-field"},
+    ]
+    assert rv.tags_for_commit(tags, "abc123") == ["1.0.21-RELEASE"]
+
+
+def test_tags_for_commit_no_match() -> None:
+    tags = [tag("1.0.20-RELEASE", "def456")]
+    assert rv.tags_for_commit(tags, "abc123") == []
+
+
+# --------------------------------------------------------------------------
+# Pure logic: resolve_upstream_version
+# --------------------------------------------------------------------------
+
+
+def test_resolve_upstream_version_single_tag() -> None:
+    assert rv.resolve_upstream_version(["1.0.21-RELEASE"], "abc123") == (1, 0, 21)
+
+
+def test_resolve_upstream_version_final_suffix() -> None:
+    assert rv.resolve_upstream_version(["1.0.18-FINAL"], "abc123") == (1, 0, 18)
+
+
+def test_resolve_upstream_version_bare() -> None:
+    assert rv.resolve_upstream_version(["1.0.22"], "abc123") == (1, 0, 22)
+
+
+def test_resolve_upstream_version_duplicate_tags_collapse() -> None:
+    # The 1.0.22 commit carries both "1.0.22" and "1.0.22-RELEASE".
+    assert rv.resolve_upstream_version(["1.0.22", "1.0.22-RELEASE"], "abc123") == (1, 0, 22)
+
+
+def test_resolve_upstream_version_ignores_non_version_tags() -> None:
+    assert rv.resolve_upstream_version(["not-a-release", "1.0.21-RELEASE"], "abc123") == (1, 0, 21)
+
+
+def test_resolve_upstream_version_no_match_raises() -> None:
+    with pytest.raises(rv.VersionError, match="carries no release tag"):
+        rv.resolve_upstream_version([], "abc123")
+
+
+def test_resolve_upstream_version_no_match_after_filtering_junk_raises() -> None:
+    with pytest.raises(rv.VersionError, match="carries no release tag"):
+        rv.resolve_upstream_version(["not-a-release"], "abc123")
+
+
+def test_resolve_upstream_version_conflicting_tags_raises() -> None:
+    with pytest.raises(rv.VersionError, match="conflicting release tags"):
+        rv.resolve_upstream_version(["1.0.21-RELEASE", "1.0.22"], "abc123")
+
+
+# --------------------------------------------------------------------------
+# Pure logic: non_draft_tag_names
+# --------------------------------------------------------------------------
+
+
+def test_non_draft_tag_names_excludes_drafts() -> None:
+    releases = [
+        release("1.10021.0", draft=False),
+        release("1.10021.1", draft=True),
+        {"tag_name": "1.10021.2"},  # no "draft" key -> defaults to False -> kept
+    ]
+    assert rv.non_draft_tag_names(releases) == ["1.10021.0", "1.10021.2"]
+
+
+def test_non_draft_tag_names_keeps_prereleases() -> None:
+    # Prereleases are not drafts, and must be kept.
+    releases = [{"tag_name": "1.10021.0", "draft": False, "prerelease": True}]
+    assert rv.non_draft_tag_names(releases) == ["1.10021.0"]
+
+
+# --------------------------------------------------------------------------
+# Pure logic: select_patch
+# --------------------------------------------------------------------------
+
+
+def test_select_patch_continues_from_newest() -> None:
+    tags = ["1.10021.0", "1.10021.1"]
+    assert rv.select_patch(tags, 10021) == 2
+
+
+def test_select_patch_restarts_at_zero_for_new_minor() -> None:
+    tags = ["1.10021.0", "1.10021.1"]
+    assert rv.select_patch(tags, 10022) == 0
+
+
+def test_select_patch_ignores_drafts_upstream_of_call() -> None:
+    # non_draft_tag_names is expected to already have filtered drafts out;
+    # select_patch itself just has to ignore tags of other minors.
+    tags = ["1.10020.9", "1.10021.1"]
+    assert rv.select_patch(tags, 10021) == 2
+
+
+def test_select_patch_no_matches_returns_zero() -> None:
+    assert rv.select_patch([], 10021) == 0
+    assert rv.select_patch(["not-a-port-tag"], 10021) == 0
+
+
+def test_select_patch_numeric_not_lexical_sort() -> None:
+    # 10 must beat 7: a lexical sort would wrongly pick "9" over "10".
+    tags = ["1.10021.7", "1.10021.10", "1.10021.9"]
+    assert rv.select_patch(tags, 10021) == 11
+
+
+# --------------------------------------------------------------------------
+# get_pinned_sha (subprocess)
+# --------------------------------------------------------------------------
+
+
+def test_get_pinned_sha_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="abc123\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert rv.get_pinned_sha() == "abc123"
+
+
+def test_get_pinned_sha_failure_with_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(returncode=128, cmd=["git"], stderr="fatal: bad revision\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(rv.VersionError, match="fatal: bad revision"):
+        rv.get_pinned_sha()
+
+
+def test_get_pinned_sha_failure_without_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(returncode=128, cmd=["git"], stderr=None)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(rv.VersionError):
+        rv.get_pinned_sha()
+
+
+# --------------------------------------------------------------------------
+# build_headers / http_get_json
+# --------------------------------------------------------------------------
+
+
+def test_build_headers_with_token() -> None:
+    headers = rv.build_headers("secret-token")
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+def test_build_headers_without_token() -> None:
+    headers = rv.build_headers(None)
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert "Authorization" not in headers
+
+
+def test_http_get_json_sends_auth_header_when_token_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    sink: list[urllib.request.Request] = []
+    monkeypatch.setattr(urllib.request, "urlopen", capturing_urlopen(sink, data={"ok": True}))
+    result = rv.http_get_json("https://api.github.com/x", "my-token")
+    assert result == {"ok": True}
+    assert sink[0].get_header("Authorization") == "Bearer my-token"
+
+
+def test_http_get_json_no_auth_header_when_token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    sink: list[urllib.request.Request] = []
+    monkeypatch.setattr(urllib.request, "urlopen", capturing_urlopen(sink, data={"ok": True}))
+    rv.http_get_json("https://api.github.com/x", None)
+    assert sink[0].get_header("Authorization") is None
+
+
+def test_http_get_json_raises_version_error_on_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        urllib.request, "urlopen", sequence_urlopen([urllib.error.URLError("boom")])
+    )
+    with pytest.raises(rv.VersionError, match="Request to .* failed"):
+        rv.http_get_json("https://api.github.com/x", None)
+
+
+# --------------------------------------------------------------------------
+# paginate
+# --------------------------------------------------------------------------
+
+
+def test_paginate_stops_on_short_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    full_page = [{"name": str(i)} for i in range(rv.PER_PAGE)]
+    short_page = [{"name": "last"}]
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([full_page, short_page]))
+    result = rv.paginate("https://api.github.com/repos/x/tags", None)
+    assert len(result) == rv.PER_PAGE + 1
+    assert result[-1]["name"] == "last"
+
+
+def test_paginate_single_short_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[{"name": "only"}]]))
+    result = rv.paginate("https://api.github.com/repos/x/tags", None)
+    assert result == [{"name": "only"}]
+
+
+def test_paginate_appends_query_with_ampersand_when_base_has_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink: list[urllib.request.Request] = []
+    monkeypatch.setattr(urllib.request, "urlopen", capturing_urlopen(sink, data=[]))
+    rv.paginate("https://api.github.com/repos/x/tags?foo=bar", None)
+    assert "foo=bar&per_page=100&page=1" in sink[0].full_url
+
+
+def test_paginate_appends_query_with_question_mark_when_base_has_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink: list[urllib.request.Request] = []
+    monkeypatch.setattr(urllib.request, "urlopen", capturing_urlopen(sink, data=[]))
+    rv.paginate("https://api.github.com/repos/x/tags", None)
+    assert "?per_page=100&page=1" in sink[0].full_url
+
+
+# --------------------------------------------------------------------------
+# fetch_libsodium_tags / fetch_releases
+# --------------------------------------------------------------------------
+
+
+def test_fetch_libsodium_tags_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[tag("1.0.21-RELEASE", "abc")]]))
+    result = rv.fetch_libsodium_tags("jedisct1/libsodium", None)
+    assert result == [tag("1.0.21-RELEASE", "abc")]
+
+
+def test_fetch_libsodium_tags_failure_wraps_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        urllib.request, "urlopen", sequence_urlopen([urllib.error.URLError("down")])
+    )
+    with pytest.raises(rv.VersionError, match="Failed to list jedisct1/libsodium tags"):
+        rv.fetch_libsodium_tags("jedisct1/libsodium", None)
+
+
+def test_fetch_releases_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[release("1.10021.0")]]))
+    result = rv.fetch_releases("esphome-libs/libsodium", None)
+    assert result == [release("1.10021.0")]
+
+
+def test_fetch_releases_failure_wraps_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        urllib.request, "urlopen", sequence_urlopen([urllib.error.URLError("down")])
+    )
+    with pytest.raises(rv.VersionError, match="Failed to list existing releases"):
+        rv.fetch_releases("esphome-libs/libsodium", None)
+
+
+# --------------------------------------------------------------------------
+# resolve_libsodium_version / resolve_port_version (integration of the above)
+# --------------------------------------------------------------------------
+
+
+def test_resolve_libsodium_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[tag("1.0.21-RELEASE", "abc")]]))
+    version, pinned_sha = rv.resolve_libsodium_version("jedisct1/libsodium", None)
+    assert version == (1, 0, 21)
+    assert pinned_sha == "abc"
+
+
+def test_resolve_port_version_continues_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen(
+            [
+                [tag("1.0.21-RELEASE", "abc")],
+                [release("1.10021.0"), release("1.10021.1")],
+            ]
+        ),
+    )
+    version, version_string = rv.resolve_port_version("jedisct1/libsodium", "esphome-libs/libsodium", None)
+    assert version == (1, 0, 21)
+    assert version_string == "1.10021.2"
+
+
+# --------------------------------------------------------------------------
+# write_github_output
+# --------------------------------------------------------------------------
+
+
+def test_write_github_output_writes_when_set(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    output_file = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    rv.write_github_output("1.10021.2")
+    assert output_file.read_text(encoding="utf-8") == "version=1.10021.2\n"
+
+
+def test_write_github_output_skips_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    # Must not raise even though there is nowhere to write.
+    rv.write_github_output("1.10021.2")
+
+
+# --------------------------------------------------------------------------
+# Known-good end-to-end scenarios (verified against the live repo).
+# --------------------------------------------------------------------------
+
+
+def test_e2e_1_0_21_release_with_prior_releases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "pinned-sha\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen(
+            [
+                [tag("1.0.21-RELEASE", "pinned-sha")],
+                [release("1.10021.0"), release("1.10021.1")],
+            ]
+        ),
+    )
+    _version, version_string = rv.resolve_port_version("jedisct1/libsodium", "esphome-libs/libsodium", None)
+    assert version_string == "1.10021.2"
+
+
+def test_e2e_1_0_22_dual_tags_no_prior_releases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "pinned-sha\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen(
+            [
+                [tag("1.0.22", "pinned-sha"), tag("1.0.22-RELEASE", "pinned-sha")],
+                [],
+            ]
+        ),
+    )
+    _version, version_string = rv.resolve_port_version("jedisct1/libsodium", "esphome-libs/libsodium", None)
+    assert version_string == "1.10022.0"
+
+
+def test_e2e_1_0_18_final_with_prior_releases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "pinned-sha\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen(
+            [
+                [tag("1.0.18-FINAL", "pinned-sha")],
+                [release("1.10018.4")],
+            ]
+        ),
+    )
+    _version, version_string = rv.resolve_port_version("jedisct1/libsodium", "esphome-libs/libsodium", None)
+    assert version_string == "1.10018.5"
+
+
+# --------------------------------------------------------------------------
+# CLI: run_resolve / run_check / main
+# --------------------------------------------------------------------------
+
+
+def test_run_resolve_prints_and_writes_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    output_file = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen([[tag("1.0.21-RELEASE", "abc")], [release("1.10021.0")]]),
+    )
+    rv.run_resolve("jedisct1/libsodium", "esphome-libs/libsodium", None)
+    captured = capsys.readouterr()
+    assert "libsodium 1.0.21 -> 1.10021.1" in captured.out
+    assert output_file.read_text(encoding="utf-8") == "version=1.10021.1\n"
+
+
+def test_run_check_prints_libsodium_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[tag("1.0.21-RELEASE", "abc")]]))
+    rv.run_check("jedisct1/libsodium", None)
+    assert capsys.readouterr().out.strip() == "1.0.21"
+
+
+def test_build_arg_parser_resolve_and_check() -> None:
+    parser = rv.build_arg_parser()
+    assert parser.parse_args(["resolve"]).command == "resolve"
+    assert parser.parse_args(["check"]).command == "check"
+
+
+def test_main_resolve_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    output_file = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "esphome-libs/libsodium")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen([[tag("1.0.21-RELEASE", "abc")], [release("1.10021.0")]]),
+    )
+    exit_code = rv.main(["resolve"])
+    assert exit_code == 0
+    assert output_file.read_text(encoding="utf-8") == "version=1.10021.1\n"
+
+
+def test_main_check_success_no_token(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[tag("1.0.21-RELEASE", "abc")]]))
+    exit_code = rv.main(["check"])
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == "1.0.21"
+
+
+def test_main_error_path_returns_1_and_prints_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    # No tags at all -> no release tag on pinned commit -> VersionError.
+    monkeypatch.setattr(urllib.request, "urlopen", sequence_urlopen([[]]))
+    exit_code = rv.main(["check"])
+    assert exit_code == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_main_default_repository_when_env_unset(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    output_file = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: subprocess.CompletedProcess([], 0, "abc\n", ""))
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        sequence_urlopen([[tag("1.0.21-RELEASE", "abc")], []]),
+    )
+    exit_code = rv.main(["resolve"])
+    assert exit_code == 0
+    assert output_file.read_text(encoding="utf-8") == "version=1.10021.0\n"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  submodule-pin:
+    name: Submodule pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - name: Check libsodium submodule is pinned to a tagged release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/resolve_version.py check
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Run test suite with branch coverage
+        run: |
+          uv run --no-project --with pytest --with pytest-cov \
+            pytest .github/scripts -q --cov=resolve_version --cov-branch \
+            --cov-report=term-missing --cov-fail-under=100

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,77 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release-drafter:
+    name: Release Drafter
+    environment: release-drafter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      # The version is 1.<libsodium version as MAJOR*10000 + MINOR*100 + PATCH>.<port patch>,
+      # so libsodium 1.0.21 gives 1.10021.N. The minor field is therefore not a
+      # semver minor: it states which libsodium release the submodule is pinned
+      # to, and it is derived here from the submodule rather than hand-edited.
+      #
+      # The libsodium version comes from the release tag on the pinned commit,
+      # NOT from the submodule's configure.ac. Between releases upstream sets
+      # configure.ac to the next, unreleased version (master currently declares
+      # 1.0.23), so parsing it would claim we ship a libsodium that does not
+      # exist yet. Requiring a release tag means a pin to an untagged commit
+      # fails this job instead, which is correct: the version scheme has no way
+      # to express "somewhere between two libsodium releases".
+      #
+      # The patch counts port releases made against that libsodium version, so
+      # it continues from the newest published release sharing this minor and
+      # restarts at 0 whenever the submodule moves to a new libsodium release.
+      #
+      # See .github/scripts/resolve_version.py for the implementation and
+      # .github/scripts/test_resolve_version.py for its tests.
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: python3 .github/scripts/resolve_version.py resolve
+
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          version: ${{ steps.version.outputs.version }}
+
+      - name: Update version files
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          sed -i "s/^version: .*/version: ${RESOLVED_VERSION}/" idf_component.yml
+          sed -i "s/^\( *\)\"version\": .*/\1\"version\": \"${RESOLVED_VERSION}\",/" library.json
+
+      - name: Commit changes
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ! git diff --quiet; then
+            git config --global user.name "esphome-libs[bot]"
+            git config --global user.email "272321744+esphome-libs[bot]@users.noreply.github.com"
+            git commit -am "Bump version to ${RESOLVED_VERSION}"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 .history/
 
 dist/
+
+# Python test artifacts from .github/scripts
+__pycache__/
+.pytest_cache/
+.coverage


### PR DESCRIPTION
Releases here are fully manual today: hand-edit the version in `idf_component.yml` and `library.json` so the two match, merge that, then create a GitHub release whose tag is that exact string. This ports the release-drafter pattern already used by micro-decoder, micro-flac, micro-opus and esp-hub75, adapted for this repo's version scheme.

On push to `main`, Release Drafter maintains the draft release and a follow-up step stamps the resolved version into both version files and commits it as `esphome-libs[bot]`.

## Version scheme

The scheme is `1.<libsodium version as MAJOR*10000 + MINOR*100 + PATCH>.<port patch>`, so libsodium 1.0.21 gives `1.10021.N`. The minor field is therefore not a semver minor: it states which libsodium release the submodule is pinned to. A PR labelled `minor` or `new-feature` resolving `1.10021.2` to `1.10022.0` would silently claim this port ships libsodium 1.0.22, so labels only ever move the port patch number.

That field is now derived rather than hand-edited. It comes from the release tag on the pinned submodule commit, **not** from the submodule's `configure.ac`: upstream bumps `AC_INIT` to the next version immediately after tagging, so master currently declares 1.0.23, and parsing it would claim we ship a libsodium that does not exist yet. Upstream also tags inconsistently (`1.0.21-RELEASE`, `1.0.18-FINAL`, bare `1.0.22`, and the 1.0.22 commit carries two tags), so all three forms are accepted and deduped.

The port patch continues from the newest published release sharing that minor and restarts at 0 when the submodule moves, so a submodule bump produces `1.10022.0` with no human step.

## Tags stay bare

`tag-template` is `$RESOLVED_VERSION`, not `v$RESOLVED_VERSION` as in the sibling repos. `publish.yml` derives `dist/libsodium-<tag>.tar.gz` from the release tag while `pio package pack` names that tarball from the `library.json` version, so a `v` prefix would make the two disagree and break publishing. Bare also matches every existing tag, so release-drafter can find the previous release.

## New CI

The repo had no CI, only `publish.yml`. This adds a `submodule-pin` job asserting the submodule always lands on a commit carrying a libsodium release tag, which fails loudly instead of guessing a version, plus a `tests` job running the resolver's suite at 100% statement and branch coverage.

## Before this can run

- The `release-drafter` environment does not exist on the repo yet. The credentials are org-level so an empty auto-created environment is fine, but it needs to exist.
- Three labels the changelog config references are missing: `breaking-change`, `bugfix`, `dependencies`. The repo has `bug`, not `bugfix`.

## Follow-ups, not in this PR

- libsodium 1.0.22 is available upstream; the submodule is still on 1.0.21.
- Now that CI exists, a `ci-gate` job on `publish.yml` (as micro-decoder has) verifying required checks passed on the release commit becomes possible.
- esphome-desktop commits via the GraphQL `createCommitOnBranch` mutation so the bump lands signed and verified as the app. This uses the simpler `git commit` and `git push` that the esphome-libs siblings use.