### PR TITLE
Yield to the ESP8266 SYS context during curve25519 scalar multiplication

### DIFF
--- a/patches/04-esp8266-scalarmult-yield.patch
+++ b/patches/04-esp8266-scalarmult-yield.patch
@@ -6,7 +6,7 @@ index 6357c5d..976653a 100644
  #include "private/ed25519_ref10.h"
  #include "utils.h"
  
-+#include "esphome_yield.h"
++#include "sodium/esphome_yield.h"
 +
  static inline uint64_t
  load_3(const unsigned char *in)
@@ -82,7 +82,7 @@ index d298922..1c60a72 100644
  #include "utils.h"
  #include "x25519_ref10.h"
  
-+#include "esphome_yield.h"
++#include "sodium/esphome_yield.h"
 +
  /*
   * Reject small order points early to mitigate the implications of

--- a/patches/04-esp8266-scalarmult-yield.patch
+++ b/patches/04-esp8266-scalarmult-yield.patch
@@ -1,39 +1,7 @@
---- a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c	2026-08-17 14:53:55
-+++ b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c	2026-08-17 14:53:55
-@@ -8,6 +8,21 @@
- #include "utils.h"
- #include "x25519_ref10.h"
- 
-+/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
-+   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
-+   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
-+   and drop inbound frames, which stalls TCP handshakes on retransmission
-+   timeouts. Yield periodically from the long loops; optimistic_yield
-+   rate-limits itself to at most one yield per interval, and the yield
-+   points do not depend on secret data. */
-+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
-+extern void optimistic_yield(unsigned int interval_us);
-+#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
-+#else
-+#define SODIUM_ESP8266_YIELD() (void) 0
-+#endif
-+
-+
- /*
-  * Reject small order points early to mitigate the implications of
-  * unexpected optimizations that would affect the ref10 code.
-@@ -104,6 +119,9 @@
- 
-     swap = 0;
-     for (pos = 254; pos >= 0; --pos) {
-+        if ((pos & 31) == 0) {
-+            SODIUM_ESP8266_YIELD();
-+        }
-         b = t[pos / 8] >> (pos & 7);
-         b &= 1;
-         swap ^= b;
---- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c	2026-08-17 14:53:55
-+++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c	2026-08-17 14:53:55
+diff --git a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
+index 6357c5d..d2f5c78 100644
+--- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
++++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
 @@ -8,6 +8,21 @@
  #include "private/ed25519_ref10.h"
  #include "utils.h"
@@ -56,7 +24,7 @@
  static inline uint64_t
  load_3(const unsigned char *in)
  {
-@@ -949,6 +964,9 @@
+@@ -949,6 +964,9 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
      ge25519_p3_0(h);
  
      for (i = 1; i < 64; i += 2) {
@@ -66,7 +34,7 @@
          ge25519_cmov8_base(&t, i / 2, e[i]);
          ge25519_madd(&r, h, &t);
          ge25519_p1p1_to_p3(h, &r);
-@@ -964,6 +982,9 @@
+@@ -964,6 +982,9 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
      ge25519_p1p1_to_p3(h, &r);
  
      for (i = 0; i < 64; i += 2) {
@@ -76,3 +44,39 @@
          ge25519_cmov8_base(&t, i / 2, e[i]);
          ge25519_madd(&r, h, &t);
          ge25519_p1p1_to_p3(h, &r);
+diff --git a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
+index d298922..21b16e1 100644
+--- a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
++++ b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
+@@ -8,6 +8,21 @@
+ #include "utils.h"
+ #include "x25519_ref10.h"
+ 
++/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
++   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
++   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
++   and drop inbound frames, which stalls TCP handshakes on retransmission
++   timeouts. Yield periodically from the long loops; optimistic_yield
++   rate-limits itself to at most one yield per interval, and the yield
++   points do not depend on secret data. */
++#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
++extern void optimistic_yield(unsigned int interval_us);
++#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
++#else
++#define SODIUM_ESP8266_YIELD() (void) 0
++#endif
++
++
+ /*
+  * Reject small order points early to mitigate the implications of
+  * unexpected optimizations that would affect the ref10 code.
+@@ -104,6 +119,9 @@ crypto_scalarmult_curve25519_ref10(unsigned char *q,
+ 
+     swap = 0;
+     for (pos = 254; pos >= 0; --pos) {
++        if ((pos & 31) == 0) {
++            SODIUM_ESP8266_YIELD();
++        }
+         b = t[pos / 8] >> (pos & 7);
+         b &= 1;
+         swap ^= b;

--- a/patches/04-esp8266-scalarmult-yield.patch
+++ b/patches/04-esp8266-scalarmult-yield.patch
@@ -1,0 +1,78 @@
+--- a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c	2026-08-17 14:53:55
++++ b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c	2026-08-17 14:53:55
+@@ -8,6 +8,21 @@
+ #include "utils.h"
+ #include "x25519_ref10.h"
+ 
++/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
++   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
++   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
++   and drop inbound frames, which stalls TCP handshakes on retransmission
++   timeouts. Yield periodically from the long loops; optimistic_yield
++   rate-limits itself to at most one yield per interval, and the yield
++   points do not depend on secret data. */
++#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
++extern void optimistic_yield(unsigned int interval_us);
++#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
++#else
++#define SODIUM_ESP8266_YIELD() (void) 0
++#endif
++
++
+ /*
+  * Reject small order points early to mitigate the implications of
+  * unexpected optimizations that would affect the ref10 code.
+@@ -104,6 +119,9 @@
+ 
+     swap = 0;
+     for (pos = 254; pos >= 0; --pos) {
++        if ((pos & 31) == 0) {
++            SODIUM_ESP8266_YIELD();
++        }
+         b = t[pos / 8] >> (pos & 7);
+         b &= 1;
+         swap ^= b;
+--- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c	2026-08-17 14:53:55
++++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c	2026-08-17 14:53:55
+@@ -8,6 +8,21 @@
+ #include "private/ed25519_ref10.h"
+ #include "utils.h"
+ 
++/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
++   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
++   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
++   and drop inbound frames, which stalls TCP handshakes on retransmission
++   timeouts. Yield periodically from the long loops; optimistic_yield
++   rate-limits itself to at most one yield per interval, and the yield
++   points do not depend on secret data. */
++#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
++extern void optimistic_yield(unsigned int interval_us);
++#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
++#else
++#define SODIUM_ESP8266_YIELD() (void) 0
++#endif
++
++
+ static inline uint64_t
+ load_3(const unsigned char *in)
+ {
+@@ -949,6 +964,9 @@
+     ge25519_p3_0(h);
+ 
+     for (i = 1; i < 64; i += 2) {
++        if ((i & 15) == 1) {
++            SODIUM_ESP8266_YIELD();
++        }
+         ge25519_cmov8_base(&t, i / 2, e[i]);
+         ge25519_madd(&r, h, &t);
+         ge25519_p1p1_to_p3(h, &r);
+@@ -964,6 +982,9 @@
+     ge25519_p1p1_to_p3(h, &r);
+ 
+     for (i = 0; i < 64; i += 2) {
++        if ((i & 15) == 0) {
++            SODIUM_ESP8266_YIELD();
++        }
+         ge25519_cmov8_base(&t, i / 2, e[i]);
+         ge25519_madd(&r, h, &t);
+         ge25519_p1p1_to_p3(h, &r);

--- a/patches/04-esp8266-scalarmult-yield.patch
+++ b/patches/04-esp8266-scalarmult-yield.patch
@@ -1,82 +1,97 @@
 diff --git a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
-index 6357c5d..d2f5c78 100644
+index 6357c5d..976653a 100644
 --- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
 +++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
-@@ -8,6 +8,21 @@
+@@ -8,6 +8,8 @@
  #include "private/ed25519_ref10.h"
  #include "utils.h"
  
-+/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
-+   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
-+   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
-+   and drop inbound frames, which stalls TCP handshakes on retransmission
-+   timeouts. Yield periodically from the long loops; optimistic_yield
-+   rate-limits itself to at most one yield per interval, and the yield
-+   points do not depend on secret data. */
-+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
-+extern void optimistic_yield(unsigned int interval_us);
-+#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
-+#else
-+#define SODIUM_ESP8266_YIELD() (void) 0
-+#endif
-+
++#include "esphome_yield.h"
 +
  static inline uint64_t
  load_3(const unsigned char *in)
  {
-@@ -949,6 +964,9 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
+@@ -68,38 +70,46 @@ fe25519_invert(fe25519 out, const fe25519 z)
+     fe25519_mul(t1, t1, t2);
+     fe25519_sq(t2, t1);
+     for (i = 1; i < 5; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t2, t2);
+     }
+     fe25519_mul(t1, t2, t1);
+     fe25519_sq(t2, t1);
+     for (i = 1; i < 10; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t2, t2);
+     }
+     fe25519_mul(t2, t2, t1);
+     fe25519_sq(t3, t2);
+     for (i = 1; i < 20; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t3, t3);
+     }
+     fe25519_mul(t2, t3, t2);
+     for (i = 1; i < 11; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t2, t2);
+     }
+     fe25519_mul(t1, t2, t1);
+     fe25519_sq(t2, t1);
+     for (i = 1; i < 50; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t2, t2);
+     }
+     fe25519_mul(t2, t2, t1);
+     fe25519_sq(t3, t2);
+     for (i = 1; i < 100; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t3, t3);
+     }
+     fe25519_mul(t2, t3, t2);
+     for (i = 1; i < 51; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t2, t2);
+     }
+     fe25519_mul(t1, t2, t1);
+     for (i = 1; i < 6; ++i) {
++        SODIUM_ESP8266_YIELD();
+         fe25519_sq(t1, t1);
+     }
+     fe25519_mul(out, t1, t0);
+@@ -949,6 +959,7 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
      ge25519_p3_0(h);
  
      for (i = 1; i < 64; i += 2) {
-+        if ((i & 15) == 1) {
-+            SODIUM_ESP8266_YIELD();
-+        }
++        SODIUM_ESP8266_YIELD();
          ge25519_cmov8_base(&t, i / 2, e[i]);
          ge25519_madd(&r, h, &t);
          ge25519_p1p1_to_p3(h, &r);
-@@ -964,6 +982,9 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
+@@ -964,6 +975,7 @@ ge25519_scalarmult_base(ge25519_p3 *h, const unsigned char *a)
      ge25519_p1p1_to_p3(h, &r);
  
      for (i = 0; i < 64; i += 2) {
-+        if ((i & 15) == 0) {
-+            SODIUM_ESP8266_YIELD();
-+        }
++        SODIUM_ESP8266_YIELD();
          ge25519_cmov8_base(&t, i / 2, e[i]);
          ge25519_madd(&r, h, &t);
          ge25519_p1p1_to_p3(h, &r);
 diff --git a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
-index d298922..21b16e1 100644
+index d298922..1c60a72 100644
 --- a/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
 +++ b/src/libsodium/crypto_scalarmult/curve25519/ref10/x25519_ref10.c
-@@ -8,6 +8,21 @@
+@@ -8,6 +8,8 @@
  #include "utils.h"
  #include "x25519_ref10.h"
  
-+/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
-+   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
-+   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
-+   and drop inbound frames, which stalls TCP handshakes on retransmission
-+   timeouts. Yield periodically from the long loops; optimistic_yield
-+   rate-limits itself to at most one yield per interval, and the yield
-+   points do not depend on secret data. */
-+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
-+extern void optimistic_yield(unsigned int interval_us);
-+#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
-+#else
-+#define SODIUM_ESP8266_YIELD() (void) 0
-+#endif
-+
++#include "esphome_yield.h"
 +
  /*
   * Reject small order points early to mitigate the implications of
   * unexpected optimizations that would affect the ref10 code.
-@@ -104,6 +119,9 @@ crypto_scalarmult_curve25519_ref10(unsigned char *q,
+@@ -104,6 +106,7 @@ crypto_scalarmult_curve25519_ref10(unsigned char *q,
  
      swap = 0;
      for (pos = 254; pos >= 0; --pos) {
-+        if ((pos & 31) == 0) {
-+            SODIUM_ESP8266_YIELD();
-+        }
++        SODIUM_ESP8266_YIELD();
          b = t[pos / 8] >> (pos & 7);
          b &= 1;
          swap ^= b;

--- a/port_include/esphome_yield.h
+++ b/port_include/esphome_yield.h
@@ -10,7 +10,11 @@
    so the cadence is ~1 ms regardless of loop cost, and a non-firing call
    is only a cycle-count read. The call sites do not depend on secret data. */
 #if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
+#ifdef __cplusplus
+extern "C" void optimistic_yield(unsigned int interval_us);
+#else
 extern void optimistic_yield(unsigned int interval_us);
+#endif
 #define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
 #else
 #define SODIUM_ESP8266_YIELD() (void) 0

--- a/port_include/esphome_yield.h
+++ b/port_include/esphome_yield.h
@@ -1,0 +1,19 @@
+#ifndef esphome_yield_H
+#define esphome_yield_H
+
+/* ESPHome ESP8266 port: WiFi and lwip only run when the sketch yields
+   (cooperative CONT/SYS scheduling). A full scalar multiplication blocks
+   for ~70-200 ms at 80 MHz, long enough for the WiFi RX queue to overflow
+   and drop inbound frames, which stalls TCP handshakes on retransmission
+   timeouts. The long loops call this every iteration; optimistic_yield
+   rate-limits itself to at most one yield per interval_us of CONT time,
+   so the cadence is ~1 ms regardless of loop cost, and a non-firing call
+   is only a cycle-count read. The call sites do not depend on secret data. */
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
+extern void optimistic_yield(unsigned int interval_us);
+#define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
+#else
+#define SODIUM_ESP8266_YIELD() (void) 0
+#endif
+
+#endif

--- a/port_include/sodium/esphome_yield.h
+++ b/port_include/sodium/esphome_yield.h
@@ -10,10 +10,11 @@
    so the cadence is ~1 ms regardless of loop cost, and a non-firing call
    is only a cycle-count read. The call sites do not depend on secret data. */
 #if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
+#include <stdint.h>
 #ifdef __cplusplus
-extern "C" void optimistic_yield(unsigned int interval_us);
+extern "C" void optimistic_yield(uint32_t interval_us);
 #else
-extern void optimistic_yield(unsigned int interval_us);
+extern void optimistic_yield(uint32_t interval_us);
 #endif
 #define SODIUM_ESP8266_YIELD() optimistic_yield(1000u)
 #else


### PR DESCRIPTION
On ESP8266 the WiFi stack and lwip run in the cooperative SYS context, which only executes when the sketch yields. A curve25519 scalar multiplication blocks CONT for about 195 ms at 80 MHz (base point multiply about 76 ms), long enough for the small WiFi RX queue to overflow under normal background broadcast traffic; the dropped frame is whatever TCP needed next (a handshake segment or a pure ACK), and the connection then stalls about two seconds until retransmission recovers it.

Measured on an esp01_1m with esphome's encrypted API against a live network, full A B A B: baseline stalled 12 of 12 attempts at 2.3 to 3.3 seconds (at both 80 and 160 MHz, so faster crypto alone does not help); with this patch alone, 0 stalls in 12 attempts at 319 to 678 ms, and combined with the esphome socket yields 0 of 12 at 313 to 457 ms with a 359 ms median; rebuilding without the patch brought back 12 of 12; reapplying it returned 0 of 12. Concurrent 20 per second pings during baseline stalls showed RTTs ramping to 700 ms followed by six consecutive losses during the crypto window; with the yields the inbound path keeps draining. The esphome side pairs with esphome/esphome#18455 which adds matching yields to the raw TCP socket paths.

The patch calls `SODIUM_ESP8266_YIELD()` (defined in the new shared port_include/esphome_yield.h) on every iteration of the Montgomery ladder, the base point multiply, and the eight squaring chains of fe25519_invert, following the existing patch file convention (04, applies after 01 to 03, verified with the pack.sh sequence). optimistic_yield rate limits itself to one yield per millisecond of CONT time, so the cadence is ~1 ms regardless of loop cost and a non firing call is only a cycle count read; the sites are guarded to ESP8266 only, compile to nothing elsewhere, and do not branch on secret data, matching the mechanism the Arduino core uses inside uart_write.

With the full cadence the measured crypto cost rises modestly (base multiply 76 to 86 ms, DH 195 to 206 ms at 80 MHz, the price of ~1 ms SYS slices) while connect times tightened; the final form of this branch validated at 0 stalls in 24 attempts, 326 to 528 ms with a 357 ms median. A coarser every fourth iteration stride was also tested and rejected: it saved no measurable crypto time (the cost is the SYS work itself, which runs either way) while letting one stall through and widening the tail, so the rate limiter remains the single cadence control. The CONT stack watermark measured during a handshake plus an in memory handshake loopback is 1824 bytes free of 4096, answering the stack depth question with comfortable margin.


