### PR TITLE
Add fast path patch for ChaCha20-Poly1305 noise operations

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -4,8 +4,9 @@
 
 set -euxo pipefail
 
-# Reset submodule state
+# Reset submodule state (clean removes files created by patches)
 git -C libsodium reset --hard HEAD
+git -C libsodium clean -fd
 
 git submodule update --init
 

--- a/patches/05-memcpy-tails.patch
+++ b/patches/05-memcpy-tails.patch
@@ -1,3 +1,7 @@
+Portable cleanups for the chacha20 partial block tail and the poly1305
+leftover buffering: copy with memcpy instead of byte loops. Standalone;
+applies to pristine upstream libsodium as well as this port.
+
 diff --git a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
 index e798072f..5ab791cd 100644
 --- a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
@@ -41,10 +45,10 @@ index e798072f..5ab791cd 100644
      }
  }
 diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
-index e909780d..4bb687d7 100644
+index e909780d..b01f0007 100644
 --- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
 +++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
-@@ -142,13 +142,12 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+@@ -142,10 +142,8 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
  
      for (;;) {
          if (bytes < 64) {
@@ -57,11 +61,7 @@ index e909780d..4bb687d7 100644
              m       = tmp;
              ctarget = c;
              c       = tmp;
-+            aligned = 1;
-         }
-         x0  = j0;
-         x1  = j1;
-@@ -274,9 +273,7 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+@@ -274,9 +272,7 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
  
          if (bytes <= 64) {
              if (bytes < 64) {

--- a/patches/05-memcpy-tails.patch
+++ b/patches/05-memcpy-tails.patch
@@ -1,0 +1,74 @@
+diff --git a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
+index e798072f..5ab791cd 100644
+--- a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
++++ b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
+@@ -1,4 +1,6 @@
+ 
++#include <string.h>
++
+ #include "poly1305_donna.h"
+ #include "crypto_verify_16.h"
+ #include "private/common.h"
+@@ -15,8 +17,6 @@ static void
+ poly1305_update(poly1305_state_internal_t *st, const unsigned char *m,
+                 unsigned long long bytes)
+ {
+-    unsigned long long i;
+-
+     /* handle leftover */
+     if (st->leftover) {
+         unsigned long long want = (poly1305_block_size - st->leftover);
+@@ -24,9 +24,7 @@ poly1305_update(poly1305_state_internal_t *st, const unsigned char *m,
+         if (want > bytes) {
+             want = bytes;
+         }
+-        for (i = 0; i < want; i++) {
+-            st->buffer[st->leftover + i] = m[i];
+-        }
++        memcpy(&st->buffer[st->leftover], m, (size_t) want);
+         bytes -= want;
+         m += want;
+         st->leftover += want;
+@@ -48,9 +46,7 @@ poly1305_update(poly1305_state_internal_t *st, const unsigned char *m,
+ 
+     /* store leftover */
+     if (bytes) {
+-        for (i = 0; i < bytes; i++) {
+-            st->buffer[st->leftover + i] = m[i];
+-        }
++        memcpy(&st->buffer[st->leftover], m, (size_t) bytes);
+         st->leftover += bytes;
+     }
+ }
+diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+index e909780d..4bb687d7 100644
+--- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
++++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+@@ -142,13 +142,12 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+ 
+     for (;;) {
+         if (bytes < 64) {
+-            memset(tmp, 0, 64);
+-            for (i = 0; i < bytes; ++i) {
+-                tmp[i] = m[i];
+-            }
++            memcpy(tmp, m, (size_t) bytes);
++            memset(tmp + bytes, 0, (size_t) (64 - bytes));
+             m       = tmp;
+             ctarget = c;
+             c       = tmp;
++            aligned = 1;
+         }
+         x0  = j0;
+         x1  = j1;
+@@ -274,9 +273,7 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+ 
+         if (bytes <= 64) {
+             if (bytes < 64) {
+-                for (i = 0; i < (unsigned int) bytes; ++i) {
+-                    ctarget[i] = c[i]; /* ctarget cannot be NULL */
+-                }
++                memcpy(ctarget, c, (size_t) bytes); /* ctarget cannot be NULL */
+             }
+             ctx->input[12] = j12;
+             ctx->input[13] = j13;

--- a/patches/06-noise-session-api.patch
+++ b/patches/06-noise-session-api.patch
@@ -1,3 +1,11 @@
+ESPHome noise session API: session persistent ChaCha20 key schedule,
+fused block0 plus payload pass with a NULL-input keystream mode, and a
+one pass Poly1305 AEAD transcript MAC. Declarations live in
+port_include/sodium/sodium_esphome.h; this patch also creates the
+marker header that gates the capability macro and forces the tail
+block onto the aligned path (safe because patch 03 aligns tmp).
+Depends on patches 03 and 05.
+
 diff --git a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
 index 5ab791cd..bfde5040 100644
 --- a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
@@ -67,7 +75,7 @@ index 5ab791cd..bfde5040 100644
      crypto_onetimeauth_poly1305_donna_implementation = {
          SODIUM_C99(.onetimeauth =) crypto_onetimeauth_poly1305_donna,
 diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
-index 4bb687d7..2e0b6685 100644
+index b01f0007..09481883 100644
 --- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
 +++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
 @@ -14,6 +14,7 @@
@@ -78,7 +86,7 @@ index 4bb687d7..2e0b6685 100644
  
  /* Load/store 32-bit LE from a 4-byte aligned pointer.
     On little-endian targets, compiles to a single aligned load/store. */
-@@ -142,9 +143,11 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+@@ -142,11 +143,14 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
  
      for (;;) {
          if (bytes < 64) {
@@ -92,8 +100,11 @@ index 4bb687d7..2e0b6685 100644
 +            }
              ctarget = c;
              c       = tmp;
-             aligned = 1;
-@@ -192,40 +195,42 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
++            aligned = 1;
+         }
+         x0  = j0;
+         x1  = j1;
+@@ -191,40 +195,42 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
          x14 = PLUS(x14, j14);
          x15 = PLUS(x15, j15);
  
@@ -170,7 +181,7 @@ index 4bb687d7..2e0b6685 100644
          }
  
          j12 = PLUSONE(j12);
-@@ -282,7 +287,9 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+@@ -281,7 +287,9 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
          }
          bytes -= 64;
          c += 64;
@@ -181,7 +192,7 @@ index 4bb687d7..2e0b6685 100644
      }
  }
  
-@@ -369,6 +376,56 @@ stream_ietf_ext_ref_xor_ic(unsigned char *c, const unsigned char *m,
+@@ -368,6 +376,63 @@ stream_ietf_ext_ref_xor_ic(unsigned char *c, const unsigned char *m,
      return 0;
  }
  
@@ -194,9 +205,16 @@ index 4bb687d7..2e0b6685 100644
 +crypto_stream_chacha20_ietf_session_init(
 +    crypto_stream_chacha20_ietf_session_state *st, const unsigned char *k)
 +{
++    chacha_ctx *ctx = (chacha_ctx *) (void *) st;
++
 +    COMPILER_ASSERT(sizeof(crypto_stream_chacha20_ietf_session_state) ==
 +                    sizeof(struct chacha_ctx));
-+    chacha_keysetup((chacha_ctx *) (void *) st, k);
++    chacha_keysetup(ctx, k);
++    /* deterministic state for a misuse of session_xor before block0_xor */
++    ctx->input[12] = 0;
++    ctx->input[13] = 0;
++    ctx->input[14] = 0;
++    ctx->input[15] = 0;
 +
 +    return 0;
 +}
@@ -238,3 +256,21 @@ index 4bb687d7..2e0b6685 100644
  struct crypto_stream_chacha20_implementation
      crypto_stream_chacha20_ref_implementation = {
          SODIUM_C99(.stream =) stream_ref,
+diff --git a/src/libsodium/include/sodium/sodium_esphome_patched.h b/src/libsodium/include/sodium/sodium_esphome_patched.h
+new file mode 100644
+index 00000000..364b2fe7
+--- /dev/null
++++ b/src/libsodium/include/sodium/sodium_esphome_patched.h
+@@ -0,0 +1,12 @@
++#ifndef sodium_esphome_patched_H
++#define sodium_esphome_patched_H
++
++/*
++ * Marker header created by patches/06-noise-session-api.patch. Its presence
++ * tells port_include/sodium/sodium_esphome.h that the tree was patched and
++ * the session/aead entry points exist, so the capability macro can never be
++ * advertised by an unpatched checkout (e.g. the generic CMake target built
++ * straight from the pristine submodule).
++ */
++
++#endif

--- a/patches/06-noise-session-api.patch
+++ b/patches/06-noise-session-api.patch
@@ -1,0 +1,240 @@
+diff --git a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
+index 5ab791cd..bfde5040 100644
+--- a/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
++++ b/src/libsodium/crypto_onetimeauth/poly1305/donna/poly1305_donna.c
+@@ -1,6 +1,8 @@
+ 
+ #include <string.h>
+ 
++#include <sodium/sodium_esphome.h>
++
+ #include "poly1305_donna.h"
+ #include "crypto_verify_16.h"
+ #include "private/common.h"
+@@ -108,6 +110,54 @@ crypto_onetimeauth_poly1305_donna_verify(const unsigned char *h,
+     return crypto_verify_16(h, correct);
+ }
+ 
++/*
++ * ESPHome extension: one-pass Poly1305 over the ChaCha20-Poly1305 AEAD
++ * transcript (ad, zero padding, ciphertext, zero padding, then the two
++ * 64-bit lengths), mirroring the MAC computed by
++ * crypto_aead_chacha20poly1305_ietf_encrypt_detached(). Calls the donna
++ * implementation directly instead of the dispatched init/update/final
++ * sequence.
++ */
++int
++crypto_onetimeauth_poly1305_aead_mac(unsigned char *mac,
++                                     const unsigned char *ad,
++                                     unsigned long long adlen,
++                                     const unsigned char *c,
++                                     unsigned long long clen,
++                                     const unsigned char *key)
++{
++    static const unsigned char _pad0[16] = { 0 };
++
++    CRYPTO_ALIGN(64) poly1305_state_internal_t st;
++    CRYPTO_ALIGN(16) unsigned char             tail[32];
++    size_t                                     rem;
++    size_t                                     pad;
++
++    poly1305_init(&st, key);
++    if (adlen > 0U) {
++        poly1305_update(&st, ad, adlen);
++        poly1305_update(&st, _pad0, (size_t) ((0x10 - adlen) & 0xf));
++    }
++    /*
++     * Process the ciphertext in whole blocks, then hash the remainder, the
++     * zero padding and both lengths from one aligned buffer in a single
++     * update. st.leftover stays zero throughout because the ad was padded
++     * to a block boundary above.
++     */
++    rem = (size_t) (clen & 15U);
++    poly1305_update(&st, c, clen - rem);
++    memcpy(tail, c + (clen - rem), rem);
++    pad = (size_t) ((0x10 - clen) & 0xf);
++    memset(tail + rem, 0, pad);
++    STORE64_LE(tail + rem + pad, adlen);
++    STORE64_LE(tail + rem + pad + 8, clen);
++    poly1305_update(&st, tail, rem + pad + 16U);
++    /* poly1305_finish wipes the state */
++    poly1305_finish(&st, mac);
++
++    return 0;
++}
++
+ struct crypto_onetimeauth_poly1305_implementation
+     crypto_onetimeauth_poly1305_donna_implementation = {
+         SODIUM_C99(.onetimeauth =) crypto_onetimeauth_poly1305_donna,
+diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+index 4bb687d7..2e0b6685 100644
+--- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
++++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
+@@ -14,6 +14,7 @@
+ #include "private/common.h"
+ #include "utils.h"
+ #include <stdint.h>
++#include <sodium/sodium_esphome.h>
+ 
+ /* Load/store 32-bit LE from a 4-byte aligned pointer.
+    On little-endian targets, compiles to a single aligned load/store. */
+@@ -142,9 +143,11 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+ 
+     for (;;) {
+         if (bytes < 64) {
+-            memcpy(tmp, m, (size_t) bytes);
+-            memset(tmp + bytes, 0, (size_t) (64 - bytes));
+-            m       = tmp;
++            if (m != NULL) {
++                memcpy(tmp, m, (size_t) bytes);
++                memset(tmp + bytes, 0, (size_t) (64 - bytes));
++                m = tmp;
++            }
+             ctarget = c;
+             c       = tmp;
+             aligned = 1;
+@@ -192,40 +195,42 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+         x14 = PLUS(x14, j14);
+         x15 = PLUS(x15, j15);
+ 
+-        if (aligned) {
+-            x0  = XOR(x0, chacha_load32_le_aligned(m + 0));
+-            x1  = XOR(x1, chacha_load32_le_aligned(m + 4));
+-            x2  = XOR(x2, chacha_load32_le_aligned(m + 8));
+-            x3  = XOR(x3, chacha_load32_le_aligned(m + 12));
+-            x4  = XOR(x4, chacha_load32_le_aligned(m + 16));
+-            x5  = XOR(x5, chacha_load32_le_aligned(m + 20));
+-            x6  = XOR(x6, chacha_load32_le_aligned(m + 24));
+-            x7  = XOR(x7, chacha_load32_le_aligned(m + 28));
+-            x8  = XOR(x8, chacha_load32_le_aligned(m + 32));
+-            x9  = XOR(x9, chacha_load32_le_aligned(m + 36));
+-            x10 = XOR(x10, chacha_load32_le_aligned(m + 40));
+-            x11 = XOR(x11, chacha_load32_le_aligned(m + 44));
+-            x12 = XOR(x12, chacha_load32_le_aligned(m + 48));
+-            x13 = XOR(x13, chacha_load32_le_aligned(m + 52));
+-            x14 = XOR(x14, chacha_load32_le_aligned(m + 56));
+-            x15 = XOR(x15, chacha_load32_le_aligned(m + 60));
+-        } else {
+-            x0  = XOR(x0, LOAD32_LE(m + 0));
+-            x1  = XOR(x1, LOAD32_LE(m + 4));
+-            x2  = XOR(x2, LOAD32_LE(m + 8));
+-            x3  = XOR(x3, LOAD32_LE(m + 12));
+-            x4  = XOR(x4, LOAD32_LE(m + 16));
+-            x5  = XOR(x5, LOAD32_LE(m + 20));
+-            x6  = XOR(x6, LOAD32_LE(m + 24));
+-            x7  = XOR(x7, LOAD32_LE(m + 28));
+-            x8  = XOR(x8, LOAD32_LE(m + 32));
+-            x9  = XOR(x9, LOAD32_LE(m + 36));
+-            x10 = XOR(x10, LOAD32_LE(m + 40));
+-            x11 = XOR(x11, LOAD32_LE(m + 44));
+-            x12 = XOR(x12, LOAD32_LE(m + 48));
+-            x13 = XOR(x13, LOAD32_LE(m + 52));
+-            x14 = XOR(x14, LOAD32_LE(m + 56));
+-            x15 = XOR(x15, LOAD32_LE(m + 60));
++        if (m != NULL) {
++            if (aligned) {
++                x0  = XOR(x0, chacha_load32_le_aligned(m + 0));
++                x1  = XOR(x1, chacha_load32_le_aligned(m + 4));
++                x2  = XOR(x2, chacha_load32_le_aligned(m + 8));
++                x3  = XOR(x3, chacha_load32_le_aligned(m + 12));
++                x4  = XOR(x4, chacha_load32_le_aligned(m + 16));
++                x5  = XOR(x5, chacha_load32_le_aligned(m + 20));
++                x6  = XOR(x6, chacha_load32_le_aligned(m + 24));
++                x7  = XOR(x7, chacha_load32_le_aligned(m + 28));
++                x8  = XOR(x8, chacha_load32_le_aligned(m + 32));
++                x9  = XOR(x9, chacha_load32_le_aligned(m + 36));
++                x10 = XOR(x10, chacha_load32_le_aligned(m + 40));
++                x11 = XOR(x11, chacha_load32_le_aligned(m + 44));
++                x12 = XOR(x12, chacha_load32_le_aligned(m + 48));
++                x13 = XOR(x13, chacha_load32_le_aligned(m + 52));
++                x14 = XOR(x14, chacha_load32_le_aligned(m + 56));
++                x15 = XOR(x15, chacha_load32_le_aligned(m + 60));
++            } else {
++                x0  = XOR(x0, LOAD32_LE(m + 0));
++                x1  = XOR(x1, LOAD32_LE(m + 4));
++                x2  = XOR(x2, LOAD32_LE(m + 8));
++                x3  = XOR(x3, LOAD32_LE(m + 12));
++                x4  = XOR(x4, LOAD32_LE(m + 16));
++                x5  = XOR(x5, LOAD32_LE(m + 20));
++                x6  = XOR(x6, LOAD32_LE(m + 24));
++                x7  = XOR(x7, LOAD32_LE(m + 28));
++                x8  = XOR(x8, LOAD32_LE(m + 32));
++                x9  = XOR(x9, LOAD32_LE(m + 36));
++                x10 = XOR(x10, LOAD32_LE(m + 40));
++                x11 = XOR(x11, LOAD32_LE(m + 44));
++                x12 = XOR(x12, LOAD32_LE(m + 48));
++                x13 = XOR(x13, LOAD32_LE(m + 52));
++                x14 = XOR(x14, LOAD32_LE(m + 56));
++                x15 = XOR(x15, LOAD32_LE(m + 60));
++            }
+         }
+ 
+         j12 = PLUSONE(j12);
+@@ -282,7 +287,9 @@ chacha20_encrypt_bytes(chacha_ctx *ctx, const uint8_t *m, uint8_t *c,
+         }
+         bytes -= 64;
+         c += 64;
+-        m += 64;
++        if (m != NULL) {
++            m += 64;
++        }
+     }
+ }
+ 
+@@ -369,6 +376,56 @@ stream_ietf_ext_ref_xor_ic(unsigned char *c, const unsigned char *m,
+     return 0;
+ }
+ 
++/*
++ * ESPHome extensions for the Noise ChaCha20-Poly1305 pattern: a session
++ * persistent cipher state whose key schedule is loaded once per session;
++ * per-message operations only rewrite the nonce and counter words.
++ */
++int
++crypto_stream_chacha20_ietf_session_init(
++    crypto_stream_chacha20_ietf_session_state *st, const unsigned char *k)
++{
++    COMPILER_ASSERT(sizeof(crypto_stream_chacha20_ietf_session_state) ==
++                    sizeof(struct chacha_ctx));
++    chacha_keysetup((chacha_ctx *) (void *) st, k);
++
++    return 0;
++}
++
++int
++crypto_stream_chacha20_ietf_session_block0_xor(
++    crypto_stream_chacha20_ietf_session_state *st, unsigned char *block0,
++    unsigned char *c, const unsigned char *m, unsigned long long mlen,
++    uint64_t nonce)
++{
++    chacha_ctx *ctx = (chacha_ctx *) (void *) st;
++
++    /* IETF nonce: 4 zero bytes followed by the 64-bit nonce, little endian */
++    ctx->input[12] = 0; /* block counter */
++    ctx->input[13] = 0;
++    ctx->input[14] = (uint32_t) nonce;
++    ctx->input[15] = (uint32_t) (nonce >> 32);
++    /* NULL input makes chacha20_encrypt_bytes store pure keystream */
++    chacha20_encrypt_bytes(ctx, NULL, block0, 64);
++    /* ctx counter is now 1; the guard skips the call entirely for the
++       block0-only decrypt setup */
++    if (mlen > 0U) {
++        chacha20_encrypt_bytes(ctx, m, c, mlen);
++    }
++
++    return 0;
++}
++
++int
++crypto_stream_chacha20_ietf_session_xor(
++    crypto_stream_chacha20_ietf_session_state *st, unsigned char *c,
++    const unsigned char *m, unsigned long long mlen)
++{
++    chacha20_encrypt_bytes((chacha_ctx *) (void *) st, m, c, mlen);
++
++    return 0;
++}
++
+ struct crypto_stream_chacha20_implementation
+     crypto_stream_chacha20_ref_implementation = {
+         SODIUM_C99(.stream =) stream_ref,

--- a/patches/06-noise-session-api.patch
+++ b/patches/06-noise-session-api.patch
@@ -75,7 +75,7 @@ index 5ab791cd..bfde5040 100644
      crypto_onetimeauth_poly1305_donna_implementation = {
          SODIUM_C99(.onetimeauth =) crypto_onetimeauth_poly1305_donna,
 diff --git a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
-index b01f0007..09481883 100644
+index b01f0007..84609a21 100644
 --- a/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
 +++ b/src/libsodium/crypto_stream/chacha20/ref/chacha20_ref.c
 @@ -14,6 +14,7 @@
@@ -192,7 +192,7 @@ index b01f0007..09481883 100644
      }
  }
  
-@@ -368,6 +376,63 @@ stream_ietf_ext_ref_xor_ic(unsigned char *c, const unsigned char *m,
+@@ -368,6 +376,66 @@ stream_ietf_ext_ref_xor_ic(unsigned char *c, const unsigned char *m,
      return 0;
  }
  
@@ -237,6 +237,9 @@ index b01f0007..09481883 100644
 +    /* ctx counter is now 1; the guard skips the call entirely for the
 +       block0-only decrypt setup */
 +    if (mlen > 0U) {
++        if (m == NULL) {
++            return -1; /* refuse to emit bare keystream on a caller bug */
++        }
 +        chacha20_encrypt_bytes(ctx, m, c, mlen);
 +    }
 +

--- a/port_include/sodium/sodium_esphome.h
+++ b/port_include/sodium/sodium_esphome.h
@@ -58,7 +58,9 @@ int crypto_stream_chacha20_ietf_session_init(
  * the Noise protocol specifies), write the block-0 keystream to block0 and,
  * when mlen > 0, encrypt m into c starting at block counter 1. block0 must
  * be at least 64 bytes: it receives the full ChaCha20 block, of which only
- * the first 32 bytes are the Poly1305 key. Leaves the state's block counter
+ * the first 32 bytes are the Poly1305 key. m and c may be NULL only when
+ * mlen is 0 (a block0-only call); a NULL m with a nonzero mlen fails with
+ * -1 rather than emitting bare keystream. Leaves the state's block counter
  * after the last block processed.
  */
 SODIUM_EXPORT
@@ -70,7 +72,11 @@ int crypto_stream_chacha20_ietf_session_block0_xor(
 
 /*
  * Continue the keystream from the state's current block counter (e.g. the
- * payload pass after a block0-only call above).
+ * payload pass after a block0-only call above). Only one continuation call
+ * per nonce is supported: a partial final block advances the counter to the
+ * next block, so chaining several calls is keystream-continuous only when
+ * every mlen is a multiple of 64. c and m must be non-NULL even when mlen
+ * is 0.
  */
 SODIUM_EXPORT
 int crypto_stream_chacha20_ietf_session_xor(

--- a/port_include/sodium/sodium_esphome.h
+++ b/port_include/sodium/sodium_esphome.h
@@ -23,11 +23,22 @@ extern "C" {
  * Capability macro for consumers (e.g. noise-c) to detect this port. The
  * value is a version number: it is bumped if the semantics of the entry
  * points below ever change, so consumers can gate on a minimum version.
- * The functions below exist only in the patched tree that this repository
- * publishes; building the pristine submodule with this header on the
- * include path is not a supported configuration.
+ *
+ * The functions below exist only in the patched tree, so the macro is
+ * gated on a marker header that patch 06 creates inside the submodule;
+ * an unpatched checkout (e.g. the generic CMake target built straight
+ * from the pristine submodule) sees the declarations but never the
+ * capability macro. Published packages always ship patched, so compilers
+ * without __has_include (which the ESP toolchains all have) fall back to
+ * defining it.
  */
-#define SODIUM_ESPHOME_NOISE_FAST_PATH 1
+#if defined(__has_include)
+# if __has_include(<sodium/sodium_esphome_patched.h>)
+#  define SODIUM_ESPHOME_NOISE_FAST_PATH 1
+# endif
+#else
+# define SODIUM_ESPHOME_NOISE_FAST_PATH 1
+#endif
 
 /*
  * Session-persistent ChaCha20 state. The key schedule is loaded once per
@@ -46,9 +57,11 @@ int crypto_stream_chacha20_ietf_session_init(
 
 /*
  * Set the IETF nonce (4 zero bytes then the 64-bit nonce, little endian, as
- * the Noise protocol specifies), write the block-0 keystream (Poly1305 key
- * material) to block0 and, when mlen > 0, encrypt m into c starting at block
- * counter 1. Leaves the state's block counter after the last block processed.
+ * the Noise protocol specifies), write the block-0 keystream to block0 and,
+ * when mlen > 0, encrypt m into c starting at block counter 1. block0 must
+ * be at least 64 bytes: it receives the full ChaCha20 block, of which only
+ * the first 32 bytes are the Poly1305 key. Leaves the state's block counter
+ * after the last block processed.
  */
 SODIUM_EXPORT
 int crypto_stream_chacha20_ietf_session_block0_xor(
@@ -70,7 +83,7 @@ int crypto_stream_chacha20_ietf_session_xor(
 /*
  * One-pass Poly1305 over the ChaCha20-Poly1305 AEAD transcript: ad, zero
  * padding, ciphertext, zero padding, then the two 64-bit lengths. ad may be
- * NULL when adlen is 0.
+ * NULL when adlen is 0; c must be non-NULL even when clen is 0.
  */
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_aead_mac(unsigned char *mac,

--- a/port_include/sodium/sodium_esphome.h
+++ b/port_include/sodium/sodium_esphome.h
@@ -1,0 +1,88 @@
+#ifndef sodium_esphome_H
+#define sodium_esphome_H
+
+/*
+ * ESPHome extensions to libsodium for the Noise ChaCha20-Poly1305 pattern.
+ *
+ * These entry points are provided by this port only (implemented by the
+ * patches in patches/), are not part of upstream libsodium, and skip the
+ * message length validation of the regular public API; callers must keep
+ * message lengths well below crypto_stream_chacha20_ietf_MESSAGEBYTES_MAX
+ * (Noise frames are at most 65535 bytes plus the MAC).
+ */
+
+#include <stdint.h>
+
+#include <sodium/export.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Capability macro for consumers (e.g. noise-c) to detect this port. The
+ * value is a version number: it is bumped if the semantics of the entry
+ * points below ever change, so consumers can gate on a minimum version.
+ * The functions below exist only in the patched tree that this repository
+ * publishes; building the pristine submodule with this header on the
+ * include path is not a supported configuration.
+ */
+#define SODIUM_ESPHOME_NOISE_FAST_PATH 1
+
+/*
+ * Session-persistent ChaCha20 state. The key schedule is loaded once per
+ * session instead of once per message, matching the fixed-key usage of the
+ * Noise protocol. The state holds key material; wipe it with
+ * sodium_memzero() when the session ends.
+ */
+typedef struct crypto_stream_chacha20_ietf_session_state {
+    uint32_t opaque[16];
+} crypto_stream_chacha20_ietf_session_state;
+
+SODIUM_EXPORT
+int crypto_stream_chacha20_ietf_session_init(
+        crypto_stream_chacha20_ietf_session_state *st, const unsigned char *k)
+            __attribute__ ((nonnull));
+
+/*
+ * Set the IETF nonce (4 zero bytes then the 64-bit nonce, little endian, as
+ * the Noise protocol specifies), write the block-0 keystream (Poly1305 key
+ * material) to block0 and, when mlen > 0, encrypt m into c starting at block
+ * counter 1. Leaves the state's block counter after the last block processed.
+ */
+SODIUM_EXPORT
+int crypto_stream_chacha20_ietf_session_block0_xor(
+        crypto_stream_chacha20_ietf_session_state *st, unsigned char *block0,
+        unsigned char *c, const unsigned char *m, unsigned long long mlen,
+        uint64_t nonce)
+            __attribute__ ((nonnull(1, 2)));
+
+/*
+ * Continue the keystream from the state's current block counter (e.g. the
+ * payload pass after a block0-only call above).
+ */
+SODIUM_EXPORT
+int crypto_stream_chacha20_ietf_session_xor(
+        crypto_stream_chacha20_ietf_session_state *st, unsigned char *c,
+        const unsigned char *m, unsigned long long mlen)
+            __attribute__ ((nonnull));
+
+/*
+ * One-pass Poly1305 over the ChaCha20-Poly1305 AEAD transcript: ad, zero
+ * padding, ciphertext, zero padding, then the two 64-bit lengths. ad may be
+ * NULL when adlen is 0.
+ */
+SODIUM_EXPORT
+int crypto_onetimeauth_poly1305_aead_mac(unsigned char *mac,
+                                         const unsigned char *ad,
+                                         unsigned long long adlen,
+                                         const unsigned char *c,
+                                         unsigned long long clen,
+                                         const unsigned char *key)
+            __attribute__ ((nonnull(1, 4, 6)));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/port_include/sodium/sodium_esphome.h
+++ b/port_include/sodium/sodium_esphome.h
@@ -28,16 +28,14 @@ extern "C" {
  * gated on a marker header that patch 06 creates inside the submodule;
  * an unpatched checkout (e.g. the generic CMake target built straight
  * from the pristine submodule) sees the declarations but never the
- * capability macro. Published packages always ship patched, so compilers
- * without __has_include (which the ESP toolchains all have) fall back to
- * defining it.
+ * capability macro. A compiler without __has_include (none of the
+ * supported toolchains) also never gets the macro, which fails safe:
+ * consumers just take their stock libsodium code path.
  */
 #if defined(__has_include)
 # if __has_include(<sodium/sodium_esphome_patched.h>)
 #  define SODIUM_ESPHOME_NOISE_FAST_PATH 1
 # endif
-#else
-# define SODIUM_ESPHOME_NOISE_FAST_PATH 1
 #endif
 
 /*


### PR DESCRIPTION
## Summary

Speeds up the ChaCha20-Poly1305 hot path used by the ESPHome noise API, split into an upstreamable patch and a port specific one.
The main consumer of this path today is log message streaming over the encrypted API, small messages where the per message fixed cost dominates, which is what these changes target. OTA over noise is planned eventually; that shifts the focus to bulk throughput, where larger noise frames amortize the fixed cost and a hand tuned chacha loop remains as a follow up.

The changes:

1. Patch 05 (portable): the partial block tail in `chacha20_encrypt_bytes` and the poly1305 leftover buffering copy with `memcpy` instead of byte loops, and the tail block always takes the aligned path since it runs from the aligned stack buffer; this is the largest win for small messages, which are the common case for API traffic.
2. Patch 06 plus `port_include/sodium/sodium_esphome.h`: a session persistent `crypto_stream_chacha20_ietf_session_state` whose key schedule is loaded once per session; `crypto_stream_chacha20_ietf_session_block0_xor` writes the Poly1305 key block as pure keystream (no memset, no xor with zeros) and encrypts the payload in the same pass; `crypto_onetimeauth_poly1305_aead_mac` computes the whole AEAD transcript in one call instead of five dispatched init/update/final calls. The declarations and capability macros live in the port owned header, so the upstream public headers are untouched and consumers can feature detect the port.

No IRAM placement; it measured no best case gain and IRAM is too scarce to spend on it.

## Benchmarks

`noise_cipherstate_encrypt` with the same pattern as `APINoiseFrameHelper::write_protobuf_messages`; baseline is current main (patches 01 to 04) with noise-c main, after is this change together with the companion noise-c change.

ESP32 (Xtensa LX6, 240 MHz, ESP-IDF):

| Size | Before | After |
|------|--------|-------|
| 50 B | 37.4 µs/op | 27.4 µs/op (27% faster) |
| 100 B | 48.8 µs/op | 38.9 µs/op (20% faster) |
| 1000 B | 234.3 µs/op | 222.2 µs/op (5% faster) |

ESP8266 (Xtensa LX106, 80 MHz, Arduino), same benchmark:

| Size | Before | After |
|------|--------|-------|
| 50 B | 190.4 µs/op | 160.2 µs/op (16% faster) |
| 100 B | 267.6 µs/op | 240.8 µs/op (10% faster) |
| 1000 B | 1672.6 µs/op | 1650.4 µs/op (1% faster) |

## Memory

Measured on the same builds: ESP32 flash grows 124 bytes and static RAM is unchanged; ESP8266 flash shrinks 956 bytes and static RAM shrinks 52 bytes (the fast path uses fewer libsodium entry points, so more code is dead stripped). Each cipher state grows 32 bytes (key schedule instead of raw key), 64 bytes per connection. Peak stack per crypto call drops from about 880 to about 528 bytes because the per operation scratch, the stacked cipher context and two wrapper frames are gone.

## Verification

All patches apply cleanly and the patched tree matches the benchmarked tree byte for byte; an encrypted API session (handshake plus bidirectional traffic) works against the patched build on ESP32 and ESP8266; the session functions were verified to produce output byte identical to the two call composition on device.

Companion PR: esphome-libs/noise-c#26 uses the new functions behind a capability macro, with the current implementation kept as fallback for stock libsodium.
